### PR TITLE
Grab first element of zscore list

### DIFF
--- a/luigi_pipeline/lib/model/seqr_mt_schema.py
+++ b/luigi_pipeline/lib/model/seqr_mt_schema.py
@@ -227,7 +227,7 @@ class SeqrSchema(BaseSeqrSchema):
                 .filter(
                     lambda x: hl.is_defined(x.gnomad_non_coding_constraint["z_score"])
                 )
-                .gnomad_non_coding_constraint.z_score
+                .gnomad_non_coding_constraint.z_score.first()
             }
         )
 


### PR DESCRIPTION
The way we have to grab all annotations when joining locus and allele keyed tables to interval key tables generates a list of structs containing the annotations. The original implementation maintained this list for gnomAD noncoding constraint zscore however the list contained a single element so this change just grabs that element or returns missing for empty lists.