### PR TITLE
Update code to make int ref optional

### DIFF
--- a/luigi_pipeline/lib/model/seqr_mt_schema.py
+++ b/luigi_pipeline/lib/model/seqr_mt_schema.py
@@ -98,7 +98,7 @@ class BaseSeqrSchema(BaseMTSchema):
     def xstop(self):
         return variant_id.get_expr_for_xpos(self.mt.locus) + hl.len(variant_id.get_expr_for_ref_allele(self.mt)) - 1
 
-    @row_annotation(disable_index=True)
+    @row_annotation()
     def rg37_locus(self):
         if self.mt.locus.dtype.reference_genome.name != "GRCh38":
             raise RowAnnotationOmit
@@ -219,6 +219,8 @@ class SeqrSchema(BaseSeqrSchema):
 
     @row_annotation()
     def gnomad_non_coding_constraint(self):
+        if self._interval_ref_data is None:
+            raise RowAnnotationOmit
         return hl.struct(
             **{
                 "z_score": self._interval_ref_data.index(
@@ -233,6 +235,8 @@ class SeqrSchema(BaseSeqrSchema):
 
     @row_annotation()
     def screen(self):
+        if self._interval_ref_data is None:
+            raise RowAnnotationOmit
         return hl.struct(
             **{
                 "region_type": self._interval_ref_data.index(

--- a/luigi_pipeline/seqr_loading.py
+++ b/luigi_pipeline/seqr_loading.py
@@ -54,7 +54,7 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
     Inherits from a Hail MT Class to get helper function logic. Main logic to do annotations here.
     """
     reference_ht_path = luigi.Parameter(description='Path to the Hail table storing locus and allele keyed reference data.')
-    interval_ref_ht_path = luigi.Parameter(description='Path to the Hail Table storing interval-keyed reference data.')
+    interval_ref_ht_path = luigi.OptionalParameter(default=None, description='Path to the Hail Table storing interval-keyed reference data.')
     clinvar_ht_path = luigi.Parameter(description='Path to the Hail table storing the clinvar variants.')
     hgmd_ht_path = luigi.Parameter(default=None,
                                    description='Path to the Hail table storing the hgmd variants.')
@@ -93,7 +93,7 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
 
     def get_schema_class_kwargs(self):
         ref = hl.read_table(self.reference_ht_path)
-        interval_ref_data = hl.read_table(self.interval_ref_ht_path)
+        interval_ref_data = hl.read_table(self.interval_ref_ht_path) if self.interval_ref_ht_path else None
         clinvar = hl.read_table(self.clinvar_ht_path)
         # hgmd is optional.
         hgmd = hl.read_table(self.hgmd_ht_path) if self.hgmd_ht_path else None


### PR DESCRIPTION
We do not have interval reference datasets for GRCh37 right now so this updates the code to make int ref optional. I also updated the rg37_locus indexing as the pipeline currently does not work for GRCh37 projects. I figured indexing this field rather than building a bunch of logic around which fields to index based on build was a simpler and cheap solution since that is a small field. These changes are needed to allow GRCh37 projects to load. 