### PR TITLE
Use hail's agg.call_stats to generate AC,AN,AF, hom alt counts

### DIFF
--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -87,7 +87,7 @@ class HailMatrixTableTask(luigi.Task):
                              reference_genome='GRCh' + self.genome_version,
                              skip_invalid_loci=True,
                              contig_recoding=recode,
-                             force_bgz=True, min_partitions=500)
+                             force_bgz=True, min_partitions=500, array_elements_required=False)
 
     @staticmethod
     def sample_type_stats(mt, genome_version, threshold=0.3):
@@ -203,6 +203,16 @@ class HailMatrixTableTask(luigi.Task):
         return mt
 
 
+    def generate_callstats(self, mt):
+        """
+        Generate call statistics for all variants in the dataset.
+
+        :param mt: MatrixTable to generate call statistics on.
+        :return: Matrixtable with gt_stats annotation.
+        """
+        return mt.annotate_rows(gt_stats=hl.agg.call_stats(mt.GT, mt.alleles))
+        
+        
 class HailElasticSearchTask(luigi.Task):
     """
     Loads a MT to ES (TODO).

--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -87,7 +87,7 @@ class HailMatrixTableTask(luigi.Task):
                              reference_genome='GRCh' + self.genome_version,
                              skip_invalid_loci=True,
                              contig_recoding=recode,
-                             force_bgz=True, min_partitions=500, array_elements_required=False)
+                             force_bgz=True, min_partitions=500)
 
     @staticmethod
     def sample_type_stats(mt, genome_version, threshold=0.3):
@@ -212,7 +212,7 @@ class HailMatrixTableTask(luigi.Task):
         """
         return mt.annotate_rows(gt_stats=hl.agg.call_stats(mt.GT, mt.alleles))
         
-        
+
 class HailElasticSearchTask(luigi.Task):
     """
     Loads a MT to ES (TODO).

--- a/luigi_pipeline/lib/model/seqr_mt_schema.py
+++ b/luigi_pipeline/lib/model/seqr_mt_schema.py
@@ -249,15 +249,19 @@ class SeqrVariantSchema(SeqrSchema):
 
     @row_annotation(name='AC')
     def ac(self):
-        return self.mt.info.AC[self.mt.a_index-1]
+        return self.mt.gt_stats.AC[1]
 
     @row_annotation(name='AF')
     def af(self):
-        return self.mt.info.AF[self.mt.a_index-1]
+        return self.mt.gt_stats.AF[1]
 
     @row_annotation(name='AN', disable_index=True)
     def an(self):
-        return self.mt.info.AN
+        return self.mt.gt_stats.AN
+
+    @row_annotation(name='homozygote_count')
+    def hom_alt(self):
+        return self.mt.gt_stats.homozygote_count[1]
 
 
 class SeqrGenotypesSchema(BaseMTSchema):

--- a/luigi_pipeline/seqr_loading.py
+++ b/luigi_pipeline/seqr_loading.py
@@ -148,16 +148,6 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
         # Named `locus_old` instead of `old_locus` because split_multi_hts drops `old_locus`.
         return hl.split_multi_hts(mt.annotate_rows(locus_old=mt.locus, alleles_old=mt.alleles))
 
-    
-    def generate_callstats(self, mt):
-        """
-        Generate call statistics for all variants in the dataset.
-
-        :param mt: MatrixTable to generate call statistics on.
-        :return: Matrixtable with gt_stats annotation.
-        """
-        return mt.annotate_rows(gt_stats=hl.agg.call_stats(mt.GT, mt.alleles))
-        
 
     @staticmethod
     def validate_mt(mt, genome_version, sample_type):


### PR DESCRIPTION
This update replaces DSP's AC,AN,AF within the INFO struct with hails callstats. This resolves a bug found by Stephanie where low qual variants were no longer being counted towards DSPs AC which is not the behavior we want. This works for all callsets, not just the WGS and is a change that will allow us to no longer require AC,AN, or AF from AnVIL users. Hail's methods generates AC,AF, and hom alt for both ref and alt so we grab the alt from this fields with [1]. We also get homozygote count for free here which was a feature request. I'm not sure if the callstats function should have a @ staticmethod decorator though? I tested this on a shard of the recent callset and the ES index is r0652_pipeline_test__wgs__grch38__variants__v02__vcfv32__20221110