### PR TITLE
Repartition the clinvar HT

### DIFF
--- a/download_and_create_reference_datasets/v02/hail_scripts/write_clinvar_ht.py
+++ b/download_and_create_reference_datasets/v02/hail_scripts/write_clinvar_ht.py
@@ -1,5 +1,9 @@
 import hail as hl
-from hail_scripts.utils.clinvar import download_and_import_latest_clinvar_vcf, CLINVAR_HT_PATH, CLINVAR_GOLD_STARS_LOOKUP
+from hail_scripts.utils.clinvar import (
+    download_and_import_latest_clinvar_vcf,
+    CLINVAR_HT_PATH,
+    CLINVAR_GOLD_STARS_LOOKUP,
+)
 from hail_scripts.utils.hail_utils import write_ht
 
 
@@ -10,8 +14,16 @@ for genome_version in ["37", "38"]:
     timestamp = hl.eval(mt.version)
 
     ht = mt.rows()
-    ht = ht.annotate(gold_stars=CLINVAR_GOLD_STARS_LOOKUP.get(hl.delimit(ht.info.CLNREVSTAT)))
+    ht = ht.annotate(
+        gold_stars=CLINVAR_GOLD_STARS_LOOKUP.get(hl.delimit(ht.info.CLNREVSTAT))
+    )
 
     ht.describe()
+    ht = ht.repartition(100)
 
-    write_ht(ht, CLINVAR_HT_PATH.format(genome_version=genome_version).replace(".ht", ".") + timestamp + ".ht")
+    write_ht(
+        ht,
+        CLINVAR_HT_PATH.format(genome_version=genome_version).replace(".ht", ".")
+        + timestamp
+        + ".ht",
+    )


### PR DESCRIPTION
The current script writes clinvar into a single partition table. This severely impacts the first step of the pipeline. Repartitioning the table to 100 partitions in its creation will increase pipeline speed by taking advantage of spark. 