### PR TITLE
Mw/move validate

### DIFF
--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -1,11 +1,11 @@
 """
 Tasks for Hail.
 """
-from collections import Counter
 import json
 import logging
 import math
 import os
+from collections import Counter
 
 import hail as hl
 import luigi
@@ -13,8 +13,9 @@ from luigi.contrib import gcs
 from luigi.parameter import ParameterVisibility
 
 from hail_scripts.elasticsearch.hail_elasticsearch_client import HailElasticsearchClient
-from lib.global_config import GlobalConfig
-import lib.hail_vep_runners as vep_runners
+
+import luigi_pipeline.lib.hail_vep_runners as vep_runners
+from luigi_pipeline.lib.global_config import GlobalConfig
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +61,7 @@ class HailMatrixTableTask(luigi.Task):
     genome_version = luigi.Parameter(description='Reference Genome Version (37 or 38)')
     vep_runner = luigi.ChoiceParameter(choices=['VEP', 'DUMMY'], default='VEP', description='Choice of which vep runner'
                                                                                             'to annotate vep.')
+    ignore_missing_samples = luigi.BoolParameter(default=False, description='Allow missing samples in the callset.')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -154,8 +156,8 @@ class HailMatrixTableTask(luigi.Task):
         """
         stats = {}
         types_to_ht_path = {
-            'noncoding': GlobalConfig().param_kwargs['validation_%s_noncoding_ht' % genome_version],
-            'coding': GlobalConfig().param_kwargs['validation_%s_coding_ht' % genome_version]
+            'noncoding': GlobalConfig().param_kwargs[f'validation_{genome_version}_noncoding_ht'],
+            'coding': GlobalConfig().param_kwargs[f'validation_{genome_version}_coding_ht']
         }
         for sample_type, ht_path in types_to_ht_path.items():
             ht = hl.read_table(ht_path)
@@ -237,7 +239,7 @@ class HailMatrixTableTask(luigi.Task):
         return runners[runner]().run(mt, genome_version, vep_config_json_path=vep_config_json_path)
 
     @staticmethod
-    def subset_samples_and_variants(mt, subset_path, ignore_missing_samples=False):
+    def subset_samples_and_variants(self, mt, subset_path):
         """
         Subset the MatrixTable to the provided list of samples and to variants present in those samples
         :param mt: MatrixTable from VCF
@@ -256,7 +258,7 @@ class HailMatrixTableTask(luigi.Task):
                       f'subsetting-table IDs matched IDs in the variant callset.\n' \
                       f'IDs that aren\'t in the callset: {missing_samples}\n' \
                       f'All callset sample IDs:{mt.s.collect()}'
-            if (subset_count > anti_join_ht_count) and ignore_missing_samples:
+            if (subset_count > anti_join_ht_count) and self.ignore_missing_samples:
                 logger.warning(message)
             else:
                 raise MatrixTableSampleSetError(message, missing_samples)

--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -238,13 +238,11 @@ class HailMatrixTableTask(luigi.Task):
 
         return runners[runner]().run(mt, genome_version, vep_config_json_path=vep_config_json_path)
 
-    @staticmethod
     def subset_samples_and_variants(self, mt, subset_path):
         """
         Subset the MatrixTable to the provided list of samples and to variants present in those samples
         :param mt: MatrixTable from VCF
         :param subset_path: Path to a file with a single column 's'
-        :param ignore_missing_samples: ignore missing samples if true unless all samples are missing
         :return: MatrixTable subsetted to list of samples
         """
         subset_ht = hl.import_table(subset_path, key='s')

--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -1,11 +1,11 @@
 """
 Tasks for Hail.
 """
+from collections import Counter
 import json
 import logging
 import math
 import os
-from collections import Counter
 
 import hail as hl
 import luigi
@@ -13,17 +13,25 @@ from luigi.contrib import gcs
 from luigi.parameter import ParameterVisibility
 
 from hail_scripts.elasticsearch.hail_elasticsearch_client import HailElasticsearchClient
-
-import luigi_pipeline.lib.hail_vep_runners as vep_runners
-from luigi_pipeline.lib.global_config import GlobalConfig
+from lib.global_config import GlobalConfig
+import lib.hail_vep_runners as vep_runners
 
 logger = logging.getLogger(__name__)
 
+GRCh37_STANDARD_CONTIGS = {'1','10','11','12','13','14','15','16','17','18','19','2','20','21','22','3','4','5','6','7','8','9','X','Y', 'MT'}
+GRCh38_STANDARD_CONTIGS = {'chr1','chr10','chr11','chr12','chr13','chr14','chr15','chr16','chr17','chr18','chr19','chr2','chr20','chr21','chr22','chr3','chr4','chr5','chr6','chr7','chr8','chr9','chrX','chrY', 'chrM'}
+OPTIONAL_CHROMOSOMES = ['MT', 'chrM', 'Y', 'chrY']
+VARIANT_THRESHOLD = 100
+CONST_GRCh37 = '37'
+CONST_GRCh38 = '38'
 
 class MatrixTableSampleSetError(Exception):
     def __init__(self, message, missing_samples):
         super().__init__(message)
         self.missing_samples = missing_samples
+
+class VCFValidationError(Exception):
+    pass
 
 
 def GCSorLocalTarget(filename):
@@ -45,11 +53,13 @@ class HailMatrixTableTask(luigi.Task):
     """
 
     source_paths = luigi.Parameter(description='Path or list of paths of VCFs to be loaded.')
+    wes_filter_source_paths = luigi.OptionalParameter(
+        default=[], description="Path or list of delivered VCFs with filter annotations."
+    )
     dest_path = luigi.Parameter(description='Path to write the matrix table.')
     genome_version = luigi.Parameter(description='Reference Genome Version (37 or 38)')
     vep_runner = luigi.ChoiceParameter(choices=['VEP', 'DUMMY'], default='VEP', description='Choice of which vep runner'
                                                                                             'to annotate vep.')
-    ignore_missing_samples = luigi.BoolParameter(default=False, description='Allow missing samples in the callset.')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -84,12 +94,52 @@ class HailMatrixTableTask(luigi.Task):
             recode = {f"{i}": f"chr{i}" for i in (list(range(1, 23)) + ['X', 'Y'])}
         elif self.genome_version == "37":
             recode = {f"chr{i}": f"{i}" for i in (list(range(1, 23)) + ['X', 'Y'])}
+        mt = hl.import_vcf(
+            self.source_paths,
+            reference_genome=self.genome_version,
+            skip_invalid_loci=True,
+            contig_recoding=recode,
+            force_bgz=True,
+            min_partitions=500,
+        )
+        if self.wes_filter_source_paths:
+            filters_ht = hl.import_vcf(
+                self.wes_filter_source_paths,
+                reference_genome=self.genome_version,
+                skip_invalid_loci=True,
+                contig_recoding=recode,
+                force_bgz=True,
+                min_partitions=500,
+            ).rows()
+            mt = mt.annotate_rows(filters=filters_ht[mt.row_key].filters)
+        return mt
 
-        return hl.import_vcf([vcf_file for vcf_file in self.source_paths],
-                             reference_genome='GRCh' + self.genome_version,
-                             skip_invalid_loci=True,
-                             contig_recoding=recode,
-                             force_bgz=True, min_partitions=500)
+    @staticmethod
+    def contig_check(mt, standard_contigs, threshold):
+        check_result_dict = {}
+        
+        # check chromosomes that are not in the VCF  
+        row_dict = mt.aggregate_rows(hl.agg.counter(mt.locus.contig))
+        contigs_set = set(row_dict.keys())
+        
+        all_missing_contigs = standard_contigs - contigs_set
+        missing_contigs_without_optional = [contig for contig in all_missing_contigs if contig not in OPTIONAL_CHROMOSOMES]
+
+        if missing_contigs_without_optional:
+            check_result_dict['Missing contig(s)'] = missing_contigs_without_optional
+            logger.warning('Missing the following chromosomes(s):{}'.format(', '.join(missing_contigs_without_optional)))
+                        
+        for k,v in row_dict.items():
+            if k not in standard_contigs:
+                check_result_dict.setdefault('Unexpected chromosome(s)',[]).append(k)
+                logger.warning('Chromosome %s is unexpected.', k)
+            elif (k not in OPTIONAL_CHROMOSOMES) and (v < threshold):
+                check_result_dict.setdefault(f'Chromosome(s) whose variants count under threshold {threshold}',[]).append(k)
+                logger.warning('Chromosome %s has %d rows, which is lower than threshold %d.', k, v, threshold)
+                                
+        return check_result_dict
+
+
 
     @staticmethod
     def sample_type_stats(mt, genome_version, threshold=0.3):
@@ -104,8 +154,8 @@ class HailMatrixTableTask(luigi.Task):
         """
         stats = {}
         types_to_ht_path = {
-            'noncoding': GlobalConfig().param_kwargs[f'validation_{genome_version}_noncoding_ht'],
-            'coding': GlobalConfig().param_kwargs[f'validation_{genome_version}_coding_ht']
+            'noncoding': GlobalConfig().param_kwargs['validation_%s_noncoding_ht' % genome_version],
+            'coding': GlobalConfig().param_kwargs['validation_%s_coding_ht' % genome_version]
         }
         for sample_type, ht_path in types_to_ht_path.items():
             ht = hl.read_table(ht_path)
@@ -117,6 +167,67 @@ class HailMatrixTableTask(luigi.Task):
             ht_stats['match'] = (ht_stats['matched_count']/ht_stats['total_count']) >= threshold
         return stats
 
+
+    @staticmethod
+    def validate_mt(mt, genome_version, sample_type):
+        """
+        Validate the mt by checking against a list of common coding and non-coding variants given its
+        genome version. This validates genome_version, variants, and the reported sample type.
+
+        :param mt: mt to validate
+        :param genome_version: reference genome version
+        :param sample_type: WGS or WES
+        :return: True or Exception
+        """
+        if genome_version == CONST_GRCh37:
+            contig_check_result = HailMatrixTableTask.contig_check(mt, GRCh37_STANDARD_CONTIGS, VARIANT_THRESHOLD)
+        elif genome_version == CONST_GRCh38:
+            contig_check_result = HailMatrixTableTask.contig_check(mt, GRCh38_STANDARD_CONTIGS, VARIANT_THRESHOLD)
+
+        if bool(contig_check_result):
+            err_msg = ''
+            for k,v in contig_check_result.items():
+                err_msg += '{k}: {v}. '.format(k=k, v=', '.join(v))
+            raise VCFValidationError(err_msg)
+
+        sample_type_stats = HailMatrixTableTask.sample_type_stats(mt, genome_version)
+
+        for name, stat in sample_type_stats.items():
+            logger.info('Table contains %i out of %i common %s variants.' %
+                        (stat['matched_count'], stat['total_count'], name))
+
+        has_coding = sample_type_stats['coding']['match']
+        has_noncoding = sample_type_stats['noncoding']['match']
+
+        if not has_coding and not has_noncoding:
+            # No common variants detected.
+            raise VCFValidationError(
+                'Genome version validation error: dataset specified as GRCh{genome_version} but doesn\'t contain '
+                'the expected number of common GRCh{genome_version} variants'.format(genome_version=genome_version)
+            )
+        elif has_noncoding and not has_coding:
+            # Non coding only.
+            raise VCFValidationError(
+                'Sample type validation error: Dataset contains noncoding variants but is missing common coding '
+                'variants for GRCh{}. Please verify that the dataset contains coding variants.' .format(genome_version)
+            )
+        elif has_coding and not has_noncoding:
+            # Only coding should be WES.
+            if sample_type != 'WES':
+                raise VCFValidationError(
+                    'Sample type validation error: dataset sample-type is specified as WGS but appears to be '
+                    'WES because it contains many common coding variants'
+                )
+        elif has_noncoding and has_coding:
+            # Both should be WGS.
+            if sample_type != 'WGS':
+                raise VCFValidationError(
+                    'Sample type validation error: dataset sample-type is specified as WES but appears to be '
+                    'WGS because it contains many common non-coding variants'
+                )
+        return True
+    
+
     def run_vep(mt, genome_version, runner='VEP', vep_config_json_path=None):
         runners = {
             'VEP': vep_runners.HailVEPRunner,
@@ -125,11 +236,13 @@ class HailMatrixTableTask(luigi.Task):
 
         return runners[runner]().run(mt, genome_version, vep_config_json_path=vep_config_json_path)
 
-    def subset_samples_and_variants(self, mt, subset_path):
+    @staticmethod
+    def subset_samples_and_variants(mt, subset_path, ignore_missing_samples=False):
         """
         Subset the MatrixTable to the provided list of samples and to variants present in those samples
         :param mt: MatrixTable from VCF
         :param subset_path: Path to a file with a single column 's'
+        :param ignore_missing_samples: ignore missing samples if true unless all samples are missing
         :return: MatrixTable subsetted to list of samples
         """
         subset_ht = hl.import_table(subset_path, key='s')
@@ -143,7 +256,7 @@ class HailMatrixTableTask(luigi.Task):
                       f'subsetting-table IDs matched IDs in the variant callset.\n' \
                       f'IDs that aren\'t in the callset: {missing_samples}\n' \
                       f'All callset sample IDs:{mt.s.collect()}'
-            if (subset_count > anti_join_ht_count) and self.ignore_missing_samples:
+            if (subset_count > anti_join_ht_count) and ignore_missing_samples:
                 logger.warning(message)
             else:
                 raise MatrixTableSampleSetError(message, missing_samples)

--- a/luigi_pipeline/seqr_loading.py
+++ b/luigi_pipeline/seqr_loading.py
@@ -29,7 +29,7 @@ def does_file_exist(path):
 def check_if_path_exists(path, label=""):
     if not does_file_exist(path):
         raise ValueError(f"{label} path not found: {path}")
-    
+
 class SeqrValidationError(Exception):
     pass
 
@@ -123,7 +123,7 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
 
         kwargs = self.get_schema_class_kwargs()
         mt = self.SCHEMA_CLASS(mt, **kwargs).annotate_all(overwrite=True).select_annotated_mt()
-        mt = self.annotate_globals(mt, kwargs.get(["clinvar_data"]))
+        mt = self.annotate_globals(mt, kwargs.get("clinvar_data"))
 
         mt.describe()
         mt.write(self.output().path, stage_locally=True, overwrite=True)

--- a/luigi_pipeline/seqr_loading.py
+++ b/luigi_pipeline/seqr_loading.py
@@ -1,43 +1,20 @@
 import logging
 import os
+import pkg_resources
 import pprint
 import sys
 
-import hail as hl
 import luigi
-import pkg_resources
+import hail as hl
 
-from luigi_pipeline.lib.hail_tasks import (
-    GCSorLocalTarget,
-    HailElasticSearchTask,
-    HailMatrixTableTask,
-    MatrixTableSampleSetError,
-)
-from luigi_pipeline.lib.model.seqr_mt_schema import (
-    SeqrGenotypesSchema,
-    SeqrVariantsAndGenotypesSchema,
-    SeqrVariantSchema,
-)
+from lib.hail_tasks import HailMatrixTableTask, HailElasticSearchTask, GCSorLocalTarget, MatrixTableSampleSetError
+from lib.model.seqr_mt_schema import SeqrVariantSchema, SeqrGenotypesSchema, SeqrVariantsAndGenotypesSchema
 
 logger = logging.getLogger(__name__)
-GRCh37_STANDARD_CONTIGS = {'1','10','11','12','13','14','15','16','17','18','19','2','20','21','22','3','4','5','6','7','8','9','X','Y', 'MT'}
-GRCh38_STANDARD_CONTIGS = {'chr1','chr10','chr11','chr12','chr13','chr14','chr15','chr16','chr17','chr18','chr19','chr2','chr20','chr21','chr22','chr3','chr4','chr5','chr6','chr7','chr8','chr9','chrX','chrY', 'chrM'}
-OPTIONAL_CHROMOSOMES = ['MT', 'chrM', 'Y', 'chrY']
-VARIANT_THRESHOLD = 100
-CONST_GRCh37 = '37'
-CONST_GRCh38 = '38'
-
-def does_file_exist(path):
-    if path.startswith("gs://"):
-        return hl.hadoop_exists(path)
-    return os.path.exists(path)
 
 def check_if_path_exists(path, label=""):
-    if not does_file_exist(path):
+    if (path.startswith("gs://") and not hl.hadoop_exists(path)) or (not path.startswith("gs://") and not os.path.exists(path)):
         raise ValueError(f"{label} path not found: {path}")
-
-class SeqrValidationError(Exception):
-    pass
 
 class SeqrVCFToMTTask(HailMatrixTableTask):
     """
@@ -46,13 +23,13 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
     reference_ht_path = luigi.Parameter(description='Path to the Hail table storing locus and allele keyed reference data.')
     interval_ref_ht_path = luigi.OptionalParameter(default=None, description='Path to the Hail Table storing interval-keyed reference data.')
     clinvar_ht_path = luigi.Parameter(description='Path to the Hail table storing the clinvar variants.')
-    hgmd_ht_path = luigi.OptionalParameter(default=None,
+    hgmd_ht_path = luigi.Parameter(default=None,
                                    description='Path to the Hail table storing the hgmd variants.')
     sample_type = luigi.ChoiceParameter(choices=['WGS', 'WES'], description='Sample type, WGS or WES', var_type=str)
     dont_validate = luigi.BoolParameter(description='Disable checking whether the dataset matches the specified '
                                                     'genome version and WGS vs. WES sample type.')
-    dataset_type = luigi.ChoiceParameter(choices=['VARIANTS', 'SV', 'MITO'], default='VARIANTS',
-                                         description='VARIANTS or SV or MITO.')
+    dataset_type = luigi.ChoiceParameter(choices=['VARIANTS', 'SV'], default='VARIANTS',
+                                         description='VARIANTS or SV.')
     remap_path = luigi.OptionalParameter(default=None,
                                          description="Path to a tsv file with two columns: s and seqr_id.")
     subset_path = luigi.OptionalParameter(default=None,
@@ -66,16 +43,12 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
     SCHEMA_CLASS = SeqrVariantsAndGenotypesSchema
 
     def run(self):
-        if self.hail_temp_dir:
-            hl.init(tmp_dir=self.hail_temp_dir) # Need to use the GCP bucket as temp storage for very large callset joins
-        
         # first validate paths
         for source_path in self.source_paths:
             check_if_path_exists(source_path, "source_path")
-        if self.dataset_type in set(['VARIANTS', 'MITO']):
-            check_if_path_exists(self.reference_ht_path, "reference_ht_path")
-            check_if_path_exists(self.clinvar_ht_path, "clinvar_ht_path")
+        check_if_path_exists(self.reference_ht_path, "reference_ht_path")
         if self.interval_ref_ht_path: check_if_path_exists(self.interval_ref_ht_path, "interval_ref_ht_path")
+        if self.clinvar_ht_path: check_if_path_exists(self.clinvar_ht_path, "clinvar_ht_path")
         if self.hgmd_ht_path: check_if_path_exists(self.hgmd_ht_path, "hgmd_ht_path")
         if self.remap_path: check_if_path_exists(self.remap_path, "remap_path")
         if self.subset_path: check_if_path_exists(self.subset_path, "subset_path")
@@ -94,14 +67,11 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
         return {'ref_data': ref, 'interval_ref_data': interval_ref_data, 'clinvar_data': clinvar_data, 'hgmd_data': hgmd}
 
     def annotate_globals(self, mt, clinvar_data):
-        mt = mt.annotate_globals(sourceFilePath=','.join(self.source_paths),
+        return mt.annotate_globals(sourceFilePath=','.join(self.source_paths),
                                  genomeVersion=self.genome_version,
                                  sampleType=self.sample_type,
-                                 datasetType=self.dataset_type,
-                                 hail_version=pkg_resources.get_distribution('hail').version)
-        if clinvar_data:
-            mt = mt.annotate_globals(clinvar_version=clinvar_data.index_globals().version)
-        return mt
+                                 hail_version=pkg_resources.get_distribution('hail').version,
+                                 clinvar_version=clinvar_data.version)
 
     def import_dataset(self):
         logger.info("Args:")
@@ -110,6 +80,8 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
         return self.import_vcf()
 
     def read_input_write_mt(self):
+        if self.hail_temp_dir:
+            hl.init(tmp_dir=self.hail_temp_dir) # Need to use the GCP bucket as temp storage for very large callset joins
         hl._set_flags(use_new_shuffle='1') # Interval ref data join causes shuffle death, this prevents it
 
         mt = self.import_dataset()
@@ -129,7 +101,8 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
 
         kwargs = self.get_schema_class_kwargs()
         mt = self.SCHEMA_CLASS(mt, **kwargs).annotate_all(overwrite=True).select_annotated_mt()
-        mt = self.annotate_globals(mt, kwargs.get("clinvar_data"))
+
+        mt = self.annotate_globals(mt, kwargs["clinvar_data"])
 
         mt.describe()
         mt.write(self.output().path, stage_locally=True, overwrite=True)
@@ -143,93 +116,6 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
         # Named `locus_old` instead of `old_locus` because split_multi_hts drops `old_locus`.
         return hl.split_multi_hts(mt.annotate_rows(locus_old=mt.locus, alleles_old=mt.alleles))
 
-    @staticmethod
-    def contig_check(mt, standard_contigs, threshold):
-        check_result_dict = {}
-
-        # check chromosomes that are not in the VCF  
-        row_dict = mt.aggregate_rows(hl.agg.counter(mt.locus.contig))
-        contigs_set = set(row_dict.keys())
-
-        all_missing_contigs = standard_contigs - contigs_set
-        missing_contigs_without_optional = [contig for contig in all_missing_contigs if contig not in OPTIONAL_CHROMOSOMES]
-
-        if missing_contigs_without_optional:
-            check_result_dict['Missing contig(s)'] = missing_contigs_without_optional
-            logger.warning('Missing the following chromosomes(s):{}'.format(', '.join(missing_contigs_without_optional)))
-
-        for k,v in row_dict.items():
-            if k not in standard_contigs:
-                check_result_dict.setdefault('Unexpected chromosome(s)',[]).append(k)
-                logger.warning(f'Chromosome {k} is unexpected.')
-            elif (k not in OPTIONAL_CHROMOSOMES) and (v < threshold):
-                check_result_dict.setdefault(f'Chromosome(s) whose variants count under threshold {threshold}',[]).append(k)
-                logger.warning(f'Chromosome {k} has {v} rows, which is lower than threshold {threshold}.')
-
-        return check_result_dict
-
-    @staticmethod
-    def validate_mt(mt, genome_version, sample_type):
-        """
-        Validate the mt by checking against a list of common coding and non-coding variants given its
-        genome version. This validates genome_version, variants, and the reported sample type.
-
-        :param mt: mt to validate
-        :param genome_version: reference genome version
-        :param sample_type: WGS or WES
-        :return: True or Exception
-        """
-        if mt is None or not isinstance(mt, hl.MatrixTable):
-            raise SeqrValidationError("mt should probably be a MatrixTable")
-
-        if genome_version == CONST_GRCh37:
-            contig_check_result = SeqrVCFToMTTask.contig_check(mt, GRCh37_STANDARD_CONTIGS, VARIANT_THRESHOLD)
-        elif genome_version == CONST_GRCh38:
-            contig_check_result = SeqrVCFToMTTask.contig_check(mt, GRCh38_STANDARD_CONTIGS, VARIANT_THRESHOLD)
-
-        if bool(contig_check_result):
-            err_msg = ''
-            for k,v in contig_check_result.items():
-                err_msg += '{k}: {v}. '.format(k=k, v=', '.join(v))
-            raise SeqrValidationError(err_msg)
-
-        sample_type_stats = HailMatrixTableTask.sample_type_stats(mt, genome_version)
-
-        for name, stat in sample_type_stats.items():
-            logger.info('Table contains %i out of %i common %s variants.' %
-                        (stat['matched_count'], stat['total_count'], name))
-
-        has_coding = sample_type_stats['coding']['match']
-        has_noncoding = sample_type_stats['noncoding']['match']
-
-        if not has_coding and not has_noncoding:
-            # No common variants detected.
-            raise SeqrValidationError(
-                'Genome version validation error: dataset specified as GRCh{genome_version} but doesn\'t contain '
-                'the expected number of common GRCh{genome_version} variants'.format(genome_version=genome_version)
-            )
-        elif has_noncoding and not has_coding:
-            # Non coding only.
-            raise SeqrValidationError(
-                'Sample type validation error: Dataset contains noncoding variants but is missing common coding '
-                'variants for GRCh{}. Please verify that the dataset contains coding variants.' .format(genome_version)
-            )
-        elif has_coding and not has_noncoding:
-            # Only coding should be WES.
-            if sample_type != 'WES':
-                raise SeqrValidationError(
-                    'Sample type validation error: dataset sample-type is specified as WGS but appears to be '
-                    'WES because it contains many common coding variants'
-                )
-        elif has_noncoding and has_coding:
-            # Both should be WGS.
-            if sample_type != 'WGS':
-                raise SeqrValidationError(
-                    'Sample type validation error: dataset sample-type is specified as WES but appears to be '
-                    'WGS because it contains many common non-coding variants'
-                )
-        return True
-
 
 class SeqrMTToESTask(HailElasticSearchTask):
     source_paths = luigi.Parameter(default="[]", description='Path or list of paths of VCFs to be loaded.')
@@ -240,11 +126,11 @@ class SeqrMTToESTask(HailElasticSearchTask):
     reference_ht_path = luigi.Parameter(default=None, description='Path to the Hail table storing the reference variants.')
     interval_ref_ht_path = luigi.Parameter(default=None, description='Path to the Hail Table storing interval-keyed reference data.')
     clinvar_ht_path = luigi.Parameter(default=None, description='Path to the Hail table storing the clinvar variants.')
-    hgmd_ht_path = luigi.OptionalParameter(default=None, description='Path to the Hail table storing the hgmd variants.')
+    hgmd_ht_path = luigi.Parameter(default=None, description='Path to the Hail table storing the hgmd variants.')
     sample_type = luigi.ChoiceParameter(default="WES", choices=['WGS', 'WES'], description='Sample type, WGS or WES')
     dont_validate = luigi.BoolParameter(description='Disable checking whether the dataset matches the specified '
                                                     'genome version and WGS vs. WES sample type.')
-    dataset_type = luigi.ChoiceParameter(choices=['VARIANTS', 'SV', 'MITO'], default='VARIANTS', description='VARIANTS or SV.')
+    dataset_type = luigi.ChoiceParameter(choices=['VARIANTS', 'SV'], default='VARIANTS', description='VARIANTS or SV.')
     remap_path = luigi.OptionalParameter(default=None, description="Path to a tsv file with two columns: s and seqr_id.")
     subset_path = luigi.OptionalParameter(default=None, description="Path to a tsv file with one column of sample IDs: s.")
     vep_config_json_path = luigi.OptionalParameter(default=None, description="Path of hail vep config .json file")

--- a/luigi_pipeline/seqr_loading.py
+++ b/luigi_pipeline/seqr_loading.py
@@ -3,8 +3,8 @@ import os
 import pprint
 import sys
 
-import luigi
 import hail as hl
+import luigi
 import pkg_resources
 
 from luigi_pipeline.lib.hail_tasks import (
@@ -28,6 +28,7 @@ def does_file_exist(path):
 
 def check_if_path_exists(path, label=""):
     if not does_file_exist(path):
+        raise ValueError(f"{label} path not found: {path}")
     
 class SeqrValidationError(Exception):
     pass
@@ -68,7 +69,6 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
         if self.dataset_type in set(['VARIANTS', 'MITO']):
             check_if_path_exists(self.reference_ht_path, "reference_ht_path")
             check_if_path_exists(self.clinvar_ht_path, "clinvar_ht_path")
-        check_if_path_exists(self.reference_ht_path, "reference_ht_path")
         if self.interval_ref_ht_path: check_if_path_exists(self.interval_ref_ht_path, "interval_ref_ht_path")
         if self.hgmd_ht_path: check_if_path_exists(self.hgmd_ht_path, "hgmd_ht_path")
         if self.remap_path: check_if_path_exists(self.remap_path, "remap_path")
@@ -123,7 +123,7 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
 
         kwargs = self.get_schema_class_kwargs()
         mt = self.SCHEMA_CLASS(mt, **kwargs).annotate_all(overwrite=True).select_annotated_mt()
-        mt = self.annotate_globals(mt, kwargs["clinvar_data"])
+        mt = self.annotate_globals(mt, kwargs.get(["clinvar_data"]))
 
         mt.describe()
         mt.write(self.output().path, stage_locally=True, overwrite=True)


### PR DESCRIPTION
This moves validate MT and contig check up a class to HailMatrixTableTask. This allows the sex inference code to inherit from somewhere that makes sense. This code also adds the ability for the pipeline to ingest VCFs that are split into two parts, genotypes and filters, which is the way DSP delivers our exome VCFs. I can move this out if youd like but seemed like a clean enough addition to have here?  