### PR TITLE
Fix broken test

### DIFF
--- a/hail_scripts/utils/download_utils_tests.py
+++ b/hail_scripts/utils/download_utils_tests.py
@@ -26,9 +26,9 @@ class DownloadUtilsTest(unittest.TestCase):
     @mock.patch('hail_scripts.utils.download_utils.parse_gs_path_to_bucket')
     def test_download_file(self, mock_get_bucket, mock_gettempdir, mock_open, mock_getsize, mock_isfile,
                            mock_logger):
-        responses.add(responses.HEAD, GZ_DATA_URL, headers={"Content-Length": "1024"}, status=200)
+        responses.add(responses.HEAD, GZ_DATA_URL, headers={"Content-Length": "1024"}, status=200, body=b' ' * 1024)
         responses.add(responses.GET, GZ_DATA_URL, body=GZ_DATA)
-        responses.add(responses.HEAD, TXT_DATA_URL, headers={"Content-Length": "1024"}, status=200)
+        responses.add(responses.HEAD, TXT_DATA_URL, headers={"Content-Length": "1024"}, status=200, body=b' ' * 1024)
         responses.add(responses.GET, TXT_DATA_URL, body='test data\nanother line\n')
 
         # Test bad url


### PR DESCRIPTION
This was a fun one!

Botocore recently enabled support for [urllib3>2] (https://github.com/boto/botocore/commit/785d22457779cdb4054b77f4bd8fbca3feaf45a2)... our other libraries have supported it for a while.

Urllib3 now enforces that a read [matches the content length](https://github.com/urllib3/urllib3/pull/2514).  The `responses` library [followed suit](https://github.com/getsentry/responses/pull/636).  

It is a totally separate issue that `responses` drops the request method somewhere... I'm gonna open a bug in that library.