### PR TITLE
bump the luigi version to 3.4.0

### DIFF
--- a/luigi_pipeline/requirements.txt
+++ b/luigi_pipeline/requirements.txt
@@ -1,4 +1,4 @@
 elasticsearch==7.9.1
 hail>=0.2.113
-luigi==2.8.11
+luigi==3.4.0
 google-api-python-client>=1.8.0


### PR DESCRIPTION
Fix for https://github.com/broadinstitute/seqr-loading-pipelines/pull/625#issuecomment-1822477463.