### PR TITLE
corrected the ref genome paths

### DIFF
--- a/docker/vep_configs/vep-GRCh37-loftee.json
+++ b/docker/vep_configs/vep-GRCh37-loftee.json
@@ -9,7 +9,7 @@
     "--minimal",
     "--assembly", "GRCh37",
     "--dir_cache", "/vep_data",
-    "--fasta", "/vep_data/homo_sapiens/Homo_sapiens.GRCh37.dna.primary_assembly.fa",
+    "--fasta", "/vep_data/homo_sapiens/Homo_sapiens.GRCh37.dna.primary_assembly.fa.gz",
     "--plugin", "LoF,human_ancestor_fa:/vep_data/loftee_data/GRCh37/human_ancestor.fa.gz,filter_position:0.05,min_intron_size:15,conservation_file:/vep_data/loftee_data/GRCh37/phylocsf_gerp.sql,gerp_file:/vep_data/loftee_data/GRCh37/GERP_scores.final.sorted.txt.gz",
     "-o", "STDOUT"
 ],

--- a/docker/vep_configs/vep-GRCh38-loftee.json
+++ b/docker/vep_configs/vep-GRCh38-loftee.json
@@ -9,7 +9,7 @@
     "--minimal",
     "--assembly", "GRCh38",
     "--dir_cache", "/vep_data",
-    "--fasta", "/vep_data/homo_sapiens/Homo_sapiens.GRCh38.dna.primary_assembly.fa",
+    "--fasta", "/vep_data/homo_sapiens/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz",
     "--plugin", "LoF,gerp_bigwig:/vep_data/loftee_data/GRCh38/gerp_conservation_scores.homo_sapiens.GRCh38.bw,human_ancestor_fa:/vep_data/loftee_data/GRCh38/human_ancestor.fa.gz,conservation_file:/vep_data/loftee_data/GRCh38/loftee.sql",
     "-o", "STDOUT"
 ],


### PR DESCRIPTION
Fasta files are [bgzipped here](https://github.com/broadinstitute/seqr-loading-pipelines/blob/aed106c8250b527197b39ddc6374d85b2942b673/docker/bin/download_reference_data.sh#L19C5-L19C5). However, vep-config argument path is plain text.