### PR TITLE
VEP can't open bgzipped ref withot htslib

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,7 +88,7 @@ RUN /usr/bin/cpanm --notest  List::MoreUtils
 
 # install VEP
 WORKDIR /ensembl-vep-release-${VEP_VERSION}
-RUN perl INSTALL.pl -a ap -n -l -g all
+RUN perl INSTALL.pl -a ap -n -g all
 RUN ln -s /ensembl-vep-release-${VEP_VERSION}/vep /vep
 
 WORKDIR /seqr-loading-pipelines


### PR DESCRIPTION
Remove the `-l` parameter to install the htslib for vep.