### PR TITLE
Account for missing parents in pedigrees

### DIFF
--- a/v03_pipeline/lib/misc/pedigree.py
+++ b/v03_pipeline/lib/misc/pedigree.py
@@ -77,17 +77,24 @@ class Family:
         for row in rows:
             # Maternal GrandParents
             maternal_s = samples[row.s].mother
-            if maternal_s and samples[maternal_s].mother:
-                samples[row.s].maternal_grandmother = samples[maternal_s].mother
-            if maternal_s and samples[maternal_s].father:
-                samples[row.s].maternal_grandfather = samples[maternal_s].father
+            if maternal_s and maternal_s not in samples:
+                # sample may be removed from the pedigree :/
+                samples[row.s].mother = None
+            elif maternal_s:
+                if samples[maternal_s].mother:
+                    samples[row.s].maternal_grandmother = samples[maternal_s].mother
+                if samples[maternal_s].father:
+                    samples[row.s].maternal_grandfather = samples[maternal_s].father
 
             # Paternal GrandParents
             paternal_s = samples[row.s].father
-            if paternal_s and samples[paternal_s].mother:
-                samples[row.s].paternal_grandmother = samples[paternal_s].mother
-            if paternal_s and samples[paternal_s].father:
-                samples[row.s].paternal_grandfather = samples[paternal_s].father
+            if paternal_s and paternal_s not in samples:
+                samples[row.s].father = None
+            elif paternal_s:
+                if samples[paternal_s].mother:
+                    samples[row.s].paternal_grandmother = samples[paternal_s].mother
+                if samples[paternal_s].father:
+                    samples[row.s].paternal_grandfather = samples[paternal_s].father
         return samples
 
     @staticmethod

--- a/v03_pipeline/lib/misc/pedigree_test.py
+++ b/v03_pipeline/lib/misc/pedigree_test.py
@@ -361,3 +361,20 @@ class PedigreesTest(unittest.TestCase):
                 ),
             ],
         )
+
+    def test_subsetted_pedigree_with_removed_parent(self) -> None:
+        pedigree_ht = import_pedigree(TEST_PEDIGREE_2)
+        pedigree_ht = pedigree_ht.filter(
+            pedigree_ht.s != 'BBL_BC1-000345_02_D1',
+        )
+        parsed_pedigree = parse_pedigree_ht_to_families(pedigree_ht)
+        family = [
+            family
+            for family in parsed_pedigree
+            if family.family_guid == 'BBL_BC1-000345_1'
+        ]
+        self.assertEqual(len(family.samples), 2)
+        self.assertIsNone(family.samples['BBL_BC1-000345_01_D1'].father)
+        self.assertEqual(
+            family.samples['BBL_BC1-000345_01_D1'].mother, 'BBL_BC1-000345_03_D1',
+        )

--- a/v03_pipeline/lib/misc/pedigree_test.py
+++ b/v03_pipeline/lib/misc/pedigree_test.py
@@ -372,7 +372,7 @@ class PedigreesTest(unittest.TestCase):
             family
             for family in parsed_pedigree
             if family.family_guid == 'BBL_BC1-000345_1'
-        ]
+        ][0]
         self.assertEqual(len(family.samples), 2)
         self.assertIsNone(family.samples['BBL_BC1-000345_01_D1'].father)
         self.assertEqual(


### PR DESCRIPTION
I've run into this behavior quite a bit after getting the "subsetted_pedigree" logic live on airflow.  