### PR TITLE
Use hail's "repartition" instead of "naive_coalesce".

### DIFF
--- a/v03_pipeline/lib/misc/io.py
+++ b/v03_pipeline/lib/misc/io.py
@@ -179,5 +179,8 @@ def write(
     # not using checkpoint to read/write here because the checkpoint codec is different, leading to a different on disk size.
     t.write(checkpoint_path)
     t = read_fn(checkpoint_path)
-    t = t.naive_coalesce(compute_hail_n_partitions(file_size_bytes(checkpoint_path)))
+    t = t.repartition(
+        compute_hail_n_partitions(file_size_bytes(checkpoint_path)),
+        shuffle=True,
+    )
     return t.write(destination_path, overwrite=True)

--- a/v03_pipeline/lib/misc/io.py
+++ b/v03_pipeline/lib/misc/io.py
@@ -44,6 +44,10 @@ def compute_hail_n_partitions(file_size_b: int) -> int:
 
 def split_multi_hts(mt: hl.MatrixTable) -> hl.MatrixTable:
     bi = mt.filter_rows(hl.len(mt.alleles) == BIALLELIC)
+    # split_multi_hts filters star alleles by default, but we 
+    # need that behavior for bi-allelic variants in addition to 
+    # multi-allelics
+    bi = bi.filter_rows(~bi.alleles.contains('*'))
     bi = bi.annotate_rows(a_index=1, was_split=False)
     multi = mt.filter_rows(hl.len(mt.alleles) > BIALLELIC)
     split = hl.split_multi_hts(multi)

--- a/v03_pipeline/lib/misc/io.py
+++ b/v03_pipeline/lib/misc/io.py
@@ -44,8 +44,8 @@ def compute_hail_n_partitions(file_size_b: int) -> int:
 
 def split_multi_hts(mt: hl.MatrixTable) -> hl.MatrixTable:
     bi = mt.filter_rows(hl.len(mt.alleles) == BIALLELIC)
-    # split_multi_hts filters star alleles by default, but we 
-    # need that behavior for bi-allelic variants in addition to 
+    # split_multi_hts filters star alleles by default, but we
+    # need that behavior for bi-allelic variants in addition to
     # multi-allelics
     bi = bi.filter_rows(~bi.alleles.contains('*'))
     bi = bi.annotate_rows(a_index=1, was_split=False)


### PR DESCRIPTION
"naive_coalesce" is "faster", but is causing a terribly unbalanced `lookup` table at the minimum.  Full shuffle seems fine to me here!