### PR TITLE
Distinct variants only

### DIFF
--- a/v03_pipeline/lib/misc/io.py
+++ b/v03_pipeline/lib/misc/io.py
@@ -51,7 +51,8 @@ def split_multi_hts(mt: hl.MatrixTable) -> hl.MatrixTable:
     bi = bi.annotate_rows(a_index=1, was_split=False)
     multi = mt.filter_rows(hl.len(mt.alleles) > BIALLELIC)
     split = hl.split_multi_hts(multi)
-    return split.union_rows(bi)
+    mt = split.union_rows(bi)
+    return mt.distinct()
 
 
 def import_gcnv_bed_file(callset_path: str) -> hl.MatrixTable:

--- a/v03_pipeline/lib/misc/io.py
+++ b/v03_pipeline/lib/misc/io.py
@@ -179,5 +179,8 @@ def write(
     # not using checkpoint to read/write here because the checkpoint codec is different, leading to a different on disk size.
     t.write(checkpoint_path)
     t = read_fn(checkpoint_path)
-    t = t.naive_coalesce(compute_hail_n_partitions(file_size_bytes(checkpoint_path)))
+    t = t.repartition(
+        compute_hail_n_partitions(file_size_bytes(checkpoint_path)),
+        shuffle=True,
+    )
     return t.write(destination_path, overwrite=True)

--- a/v03_pipeline/lib/misc/io.py
+++ b/v03_pipeline/lib/misc/io.py
@@ -44,6 +44,10 @@ def compute_hail_n_partitions(file_size_b: int) -> int:
 
 def split_multi_hts(mt: hl.MatrixTable) -> hl.MatrixTable:
     bi = mt.filter_rows(hl.len(mt.alleles) == BIALLELIC)
+    # split_multi_hts filters star alleles by default, but we 
+    # need that behavior for bi-allelic variants in addition to 
+    # multi-allelics
+    bi = bi.filter_rows(~bi.alleles.contains('*'))
     bi = bi.annotate_rows(a_index=1, was_split=False)
     multi = mt.filter_rows(hl.len(mt.alleles) > BIALLELIC)
     split = hl.split_multi_hts(multi)

--- a/v03_pipeline/lib/misc/io.py
+++ b/v03_pipeline/lib/misc/io.py
@@ -52,7 +52,7 @@ def split_multi_hts(mt: hl.MatrixTable) -> hl.MatrixTable:
     multi = mt.filter_rows(hl.len(mt.alleles) > BIALLELIC)
     split = hl.split_multi_hts(multi)
     mt = split.union_rows(bi)
-    return mt.distinct()
+    return mt.distinct_by_row()
 
 
 def import_gcnv_bed_file(callset_path: str) -> hl.MatrixTable:

--- a/v03_pipeline/lib/misc/io.py
+++ b/v03_pipeline/lib/misc/io.py
@@ -44,8 +44,8 @@ def compute_hail_n_partitions(file_size_b: int) -> int:
 
 def split_multi_hts(mt: hl.MatrixTable) -> hl.MatrixTable:
     bi = mt.filter_rows(hl.len(mt.alleles) == BIALLELIC)
-    # split_multi_hts filters star alleles by default, but we 
-    # need that behavior for bi-allelic variants in addition to 
+    # split_multi_hts filters star alleles by default, but we
+    # need that behavior for bi-allelic variants in addition to
     # multi-allelics
     bi = bi.filter_rows(~bi.alleles.contains('*'))
     bi = bi.annotate_rows(a_index=1, was_split=False)

--- a/v03_pipeline/lib/misc/validation.py
+++ b/v03_pipeline/lib/misc/validation.py
@@ -10,6 +10,17 @@ class SeqrValidationError(Exception):
     pass
 
 
+def validate_no_duplicate_variants(
+    mt: hl.MatrixTable,
+) -> None:
+    ht = mt.rows()
+    ht = ht.group_by(*ht.key).aggregate(n=hl.agg.count())
+    ht = ht.filter(ht.n > 1)
+    if ht.count() > 0:
+        msg = f'Variants are present multiple times in the callset: {ht.collect()}'
+        raise SeqrValidationError(msg)
+
+
 def validate_expected_contig_frequency(
     mt: hl.MatrixTable,
     reference_genome: ReferenceGenome,

--- a/v03_pipeline/lib/tasks/write_imported_callset.py
+++ b/v03_pipeline/lib/tasks/write_imported_callset.py
@@ -8,6 +8,7 @@ from v03_pipeline.lib.misc.io import (
 )
 from v03_pipeline.lib.misc.validation import (
     validate_expected_contig_frequency,
+    validate_no_duplicate_variants,
     validate_sample_type,
 )
 from v03_pipeline.lib.model import CachedReferenceDatasetQuery
@@ -81,6 +82,7 @@ class WriteImportedCallsetTask(BaseWriteTask):
                 ),
             )
         if self.validate and self.dataset_type.can_run_validation:
+            validate_no_duplicate_variants(mt)
             validate_expected_contig_frequency(mt, self.reference_genome)
             coding_and_noncoding_ht = hl.read_table(
                 valid_cached_reference_dataset_query_path(


### PR DESCRIPTION
We have a single set of AnVIL project that contain duplicate variants.  Literally:

```
In [15]: mt.filter_rows(mt.locus.position == 3834167).GT.show()
+---------------+------------+--------------+==================>  (24 + 1) / 25]
| locus         | alleles    | 'sample_id'.GT |
+---------------+------------+--------------+
| locus<GRCh38> | array<str> | call         |
+---------------+------------+--------------+
| chr1:3834167  | ["T","G"]  | 1|0          |
| chr1:3834167  | ["T","G"]  | 1|1          |
+---------------+------------+--------------+
```

I think also reasonable to just throw an exception here... but that might end up being more work for us in the long run.