### PR TITLE
Add protection against a user supplying the wrong sample type on a re-run.

### DIFF
--- a/v03_pipeline/lib/tasks/write_imported_callset.py
+++ b/v03_pipeline/lib/tasks/write_imported_callset.py
@@ -33,7 +33,7 @@ class WriteImportedCallsetTask(BaseWriteTask):
 
     def complete(self) -> luigi.Target:
         return super().complete() and hl.eval(
-            self.sample_type == hl.read_matrix_table(self.output().path).sample_type,
+            self.sample_type.value == hl.read_matrix_table(self.output().path).sample_type,
         )
 
     def output(self) -> luigi.Target:
@@ -102,6 +102,6 @@ class WriteImportedCallsetTask(BaseWriteTask):
                 self.reference_genome,
                 self.sample_type,
             )
-        return mt.annotate(
-            sample_type=self.sample_type,
+        return mt.annotate_globals(
+            sample_type=self.sample_type.value,
         )

--- a/v03_pipeline/lib/tasks/write_imported_callset.py
+++ b/v03_pipeline/lib/tasks/write_imported_callset.py
@@ -31,6 +31,11 @@ class WriteImportedCallsetTask(BaseWriteTask):
         parsing=luigi.BoolParameter.EXPLICIT_PARSING,
     )
 
+    def complete(self) -> luigi.Target:
+        return super().complete() and hl.eval(
+            self.sample_type == hl.read_table(self.output().path).sample_type
+        )
+
     def output(self) -> luigi.Target:
         return GCSorLocalTarget(
             imported_callset_path(
@@ -97,4 +102,6 @@ class WriteImportedCallsetTask(BaseWriteTask):
                 self.reference_genome,
                 self.sample_type,
             )
-        return mt
+        return mt.annotate(
+            sample_type=self.sample_type,
+        )

--- a/v03_pipeline/lib/tasks/write_imported_callset.py
+++ b/v03_pipeline/lib/tasks/write_imported_callset.py
@@ -32,10 +32,10 @@ class WriteImportedCallsetTask(BaseWriteTask):
     )
 
     def complete(self) -> luigi.Target:
-        mt = hl.read_matrix_table(self.output().path)
-        return super().complete() and hasattr('sample_type', mt) and hl.eval(
-            self.sample_type.value == mt.sample_type,
-        )
+        if super().complete():
+            mt = hl.read_matrix_table(self.output().path)
+            return hasattr(mt, 'sample_type') and hl.eval(self.sample_type.value == mt.sample_type)
+        return False
 
     def output(self) -> luigi.Target:
         return GCSorLocalTarget(

--- a/v03_pipeline/lib/tasks/write_imported_callset.py
+++ b/v03_pipeline/lib/tasks/write_imported_callset.py
@@ -33,7 +33,7 @@ class WriteImportedCallsetTask(BaseWriteTask):
 
     def complete(self) -> luigi.Target:
         return super().complete() and hl.eval(
-            self.sample_type == hl.read_table(self.output().path).sample_type
+            self.sample_type == hl.read_table(self.output().path).sample_type,
         )
 
     def output(self) -> luigi.Target:

--- a/v03_pipeline/lib/tasks/write_imported_callset.py
+++ b/v03_pipeline/lib/tasks/write_imported_callset.py
@@ -32,8 +32,9 @@ class WriteImportedCallsetTask(BaseWriteTask):
     )
 
     def complete(self) -> luigi.Target:
-        return super().complete() and hl.eval(
-            self.sample_type.value == hl.read_matrix_table(self.output().path).sample_type,
+        mt = hl.read_matrix_table(self.output().path)
+        return super().complete() and hasattr('sample_type', mt) and hl.eval(
+            self.sample_type.value == mt.sample_type,
         )
 
     def output(self) -> luigi.Target:

--- a/v03_pipeline/lib/tasks/write_imported_callset.py
+++ b/v03_pipeline/lib/tasks/write_imported_callset.py
@@ -33,7 +33,7 @@ class WriteImportedCallsetTask(BaseWriteTask):
 
     def complete(self) -> luigi.Target:
         return super().complete() and hl.eval(
-            self.sample_type == hl.read_table(self.output().path).sample_type,
+            self.sample_type == hl.read_matrix_table(self.output().path).sample_type,
         )
 
     def output(self) -> luigi.Target:


### PR DESCRIPTION
This is fixing a potential (I'm _99.9%_ sure this hasn't happened, but not 100% sure) issue where:
1) sample type is correctly supplied and the callset passes validation for that sample type
2) a project is re-run with the same callset but with the wrong sample type.  

The wrong sample type will be passed onwards to the project/family tables and will be annotated there.  The data is correct and fine, but I don't think we want to allow that edge case.  