### PR TITLE
ruff format entire repo

### DIFF
--- a/v03_pipeline/lib/annotations/mito.py
+++ b/v03_pipeline/lib/annotations/mito.py
@@ -79,9 +79,13 @@ def gt_stats(
         ref_samples_length = row.ref_samples[project_guid].length()
         heteroplasmic_samples_length = row.heteroplasmic_samples[project_guid].length()
         homoplasmic_samples_length = row.homoplasmic_samples[project_guid].length()
-        AC_het += heteroplasmic_samples_length # noqa: N806
-        AC_hom += homoplasmic_samples_length # noqa: N806
-        AN += (ref_samples_length + heteroplasmic_samples_length + homoplasmic_samples_length) # noqa: N806
+        AC_het += heteroplasmic_samples_length  # noqa: N806
+        AC_hom += homoplasmic_samples_length  # noqa: N806
+        AN += (  # noqa: N806
+            ref_samples_length
+            + heteroplasmic_samples_length
+            + homoplasmic_samples_length
+        )
     return hl.Struct(
         AC_het=AC_het,
         AF_het=hl.float32(AC_het / AN),

--- a/v03_pipeline/lib/annotations/snv_indel_test.py
+++ b/v03_pipeline/lib/annotations/snv_indel_test.py
@@ -25,9 +25,21 @@ class SNVTest(unittest.TestCase):
             [
                 {
                     'id': 0,
-                    'ref_samples': hl.Struct(project_1={'a', 'c'}, project_2=set(), R0607_gregor_training_project_=set()),
-                    'het_samples': hl.Struct(project_1={'b', 'd'}, project_2=set(), R0607_gregor_training_project_=set()),
-                    'hom_samples': hl.Struct(project_1={'e', 'f'}, project_2=set(), R0607_gregor_training_project_={'l', 'm'}),
+                    'ref_samples': hl.Struct(
+                        project_1={'a', 'c'},
+                        project_2=set(),
+                        R0607_gregor_training_project_=set(),
+                    ),
+                    'het_samples': hl.Struct(
+                        project_1={'b', 'd'},
+                        project_2=set(),
+                        R0607_gregor_training_project_=set(),
+                    ),
+                    'hom_samples': hl.Struct(
+                        project_1={'e', 'f'},
+                        project_2=set(),
+                        R0607_gregor_training_project_={'l', 'm'},
+                    ),
                 },
                 {
                     'id': 1,
@@ -36,8 +48,16 @@ class SNVTest(unittest.TestCase):
                         project_2=set(),
                         R0607_gregor_training_project_={'l', 'm'},
                     ),
-                    'het_samples': hl.Struct(project_1=set(), project_2=set(), R0607_gregor_training_project_=set()),
-                    'hom_samples': hl.Struct(project_1=set(), project_2=set(), R0607_gregor_training_project_=set()),
+                    'het_samples': hl.Struct(
+                        project_1=set(),
+                        project_2=set(),
+                        R0607_gregor_training_project_=set(),
+                    ),
+                    'hom_samples': hl.Struct(
+                        project_1=set(),
+                        project_2=set(),
+                        R0607_gregor_training_project_=set(),
+                    ),
                 },
             ],
             hl.tstruct(

--- a/v03_pipeline/lib/misc/io.py
+++ b/v03_pipeline/lib/misc/io.py
@@ -112,9 +112,12 @@ def import_vcf(
         skip_invalid_loci=True,
         contig_recoding=reference_genome.contig_recoding(),
         force_bgz=True,
-        find_replace=('nul', '.'), # Required for internal exome callsets (+ some AnVIL requests)
+        find_replace=(
+            'nul',
+            '.',
+        ),  # Required for internal exome callsets (+ some AnVIL requests)
         array_elements_required=False,
-        call_fields=[], # PGT is unused downstream, but is occasionally present in old VCFs!
+        call_fields=[],  # PGT is unused downstream, but is occasionally present in old VCFs!
     )
 
 

--- a/v03_pipeline/lib/misc/math.py
+++ b/v03_pipeline/lib/misc/math.py
@@ -1,4 +1,8 @@
-def constrain(number: int | float, lower_bound: int | float, upper_bound: int | float) -> int:
+def constrain(
+    number: int | float,
+    lower_bound: int | float,
+    upper_bound: int | float,
+) -> int:
     if lower_bound > upper_bound:
         msg = 'Lower bound should be less than or equal to upper bound'
         raise ValueError(msg)

--- a/v03_pipeline/lib/misc/math_test.py
+++ b/v03_pipeline/lib/misc/math_test.py
@@ -4,7 +4,6 @@ from v03_pipeline.lib.misc.math import constrain
 
 
 class TestConstrainFunction(unittest.TestCase):
-
     def test_constrain(self):
         self.assertEqual(constrain(5, 0, 10), 5)
         self.assertEqual(constrain(-3, 0, 10), 0)

--- a/v03_pipeline/lib/misc/sample_entries.py
+++ b/v03_pipeline/lib/misc/sample_entries.py
@@ -8,7 +8,9 @@ def globalize_sample_ids(ht: hl.Table) -> hl.Table:
             # NB: normal python expression here because the row is localized.
             # I had an easier time with this than hl.agg.take(1), which was an
             # alternative implementation.
-            [e.s for e in row[0].entries] if (row and len(row[0].entries) > 0) else hl.empty_array(hl.tstr)
+            [e.s for e in row[0].entries]
+            if (row and len(row[0].entries) > 0)
+            else hl.empty_array(hl.tstr)
         ),
     )
     return ht.annotate(entries=ht.entries.map(lambda s: s.drop('s')))

--- a/v03_pipeline/lib/misc/sample_entries_test.py
+++ b/v03_pipeline/lib/misc/sample_entries_test.py
@@ -327,7 +327,6 @@ class SampleEntriesTest(unittest.TestCase):
             ],
         )
 
-
     def test_filter_all_callset_entries(self) -> None:
         entries_ht = hl.Table.parallelize(
             [

--- a/v03_pipeline/lib/tasks/update_variant_annotations_table_with_new_samples.py
+++ b/v03_pipeline/lib/tasks/update_variant_annotations_table_with_new_samples.py
@@ -205,7 +205,11 @@ class UpdateVariantAnnotationsTableWithNewSamplesTask(BaseVariantAnnotationsTabl
         new_variants_ht = callset_ht.anti_join(ht)
         new_variants_count = new_variants_ht.count()
         new_variants_ht = new_variants_ht.repartition(
-            constrain(math.ceil(new_variants_count / VARIANTS_PER_VEP_PARTITION), 10, 10000),
+            constrain(
+                math.ceil(new_variants_count / VARIANTS_PER_VEP_PARTITION),
+                10,
+                10000,
+            ),
         )
         new_variants_ht = run_vep(
             new_variants_ht,


### PR DESCRIPTION
I definitely forgot to run the ruff format command when I updated the repo lint settings. Now I remember to run `ruff` _and_ `ruff format` every time 😛