### PR TITLE
fix version mismatch error message

### DIFF
--- a/v03_pipeline/lib/reference_data/dataset_table_operations.py
+++ b/v03_pipeline/lib/reference_data/dataset_table_operations.py
@@ -179,7 +179,7 @@ def parse_dataset_version(
         .when(hl.is_missing(annotated_version), config_version)
         .when(annotated_version == config_version, config_version)
         .or_error(
-            f'found mismatching versions for dataset {dataset}, {config_version}, {hl.eval(annotated_version)}',
+            f'found mismatching versions for dataset {dataset}. config version: {config_version}, ht version: {annotated_version}',
         )
     )
 


### PR DESCRIPTION
most recent failure is due to a version but I'm not sure which dataset since the error message never evaluated
 https://console.cloud.google.com/dataproc/jobs/UpdateVariantAnnotationsTableWithNewSamplesTask_20240301_654ea643/monitoring?region=us-central1&project=seqr-project