### PR TITLE
bugfix for project table updates

### DIFF
--- a/v03_pipeline/lib/misc/family_entries.py
+++ b/v03_pipeline/lib/misc/family_entries.py
@@ -107,7 +107,7 @@ def remove_new_callset_family_guids(
         family_entries=(
             hl.array(family_indexes_to_keep).map(lambda i: ht.family_entries[i])
             if len(family_indexes_to_keep) > 0
-            else hl.missing(ht.family_entries.dtype.element_type)
+            else hl.missing(ht.family_entries.dtype)
         ),
     )
     return ht.annotate_globals(

--- a/v03_pipeline/lib/tasks/update_project_table.py
+++ b/v03_pipeline/lib/tasks/update_project_table.py
@@ -100,9 +100,7 @@ class UpdateProjectTableTask(BaseUpdateTask):
         # This was the least gross way
         if 'family_entries' not in ht.row_value:
             ht = ht.annotate(
-                family_entries=hl.empty_array(
-                    hl.tarray(callset_ht.family_entries.dtype.element_type),
-                ),
+                family_entries=hl.missing(callset_ht.family_entries.dtype),
             )
         ht = remove_new_callset_family_guids(
             ht,


### PR DESCRIPTION
- this has already been refactored/fixed with the lookup table work, but the pipeline broke on this edge case (all families being removed from a project table during an update) just now.