### PR TITLE
add some logging for crdq debugging

### DIFF
--- a/v03_pipeline/lib/tasks/base/base_hail_table_task.py
+++ b/v03_pipeline/lib/tasks/base/base_hail_table_task.py
@@ -17,6 +17,7 @@ class BaseHailTableTask(luigi.Task):
         raise NotImplementedError
 
     def complete(self) -> bool:
+        logger.info(f'BaseHailTableTask: checking if {self.output().path} exists')
         return GCSorLocalFolderTarget(self.output().path).exists()
 
     def init_hail(self):
@@ -33,7 +34,7 @@ class BaseHailTableTask(luigi.Task):
 
 @luigi.Task.event_handler(luigi.Event.DEPENDENCY_DISCOVERED)
 def dependency_discovered(task, dependency):
-    logger.info(f'{task} dependency_discovered {dependency}')
+    logger.info(f'{task} dependency_discovered {dependency} at {task.output()}')
 
 
 @luigi.Task.event_handler(luigi.Event.DEPENDENCY_MISSING)
@@ -43,7 +44,7 @@ def dependency_missing(task):
 
 @luigi.Task.event_handler(luigi.Event.DEPENDENCY_PRESENT)
 def dependency_present(task):
-    logger.info(f'{task} dependency_present')
+    logger.info(f'{task} dependency_present at {task.output()}')
 
 
 @luigi.Task.event_handler(luigi.Event.START)

--- a/v03_pipeline/lib/tasks/reference_data/updated_cached_reference_dataset_query.py
+++ b/v03_pipeline/lib/tasks/reference_data/updated_cached_reference_dataset_query.py
@@ -1,6 +1,7 @@
 import hail as hl
 import luigi
 
+from v03_pipeline.lib.logger import get_logger
 from v03_pipeline.lib.model import (
     CachedReferenceDatasetQuery,
     Env,
@@ -25,12 +26,17 @@ from v03_pipeline.lib.tasks.reference_data.updated_reference_dataset_collection 
     UpdatedReferenceDatasetCollectionTask,
 )
 
+logger = get_logger(__name__)
+
 
 class UpdatedCachedReferenceDatasetQuery(BaseWriteTask):
     crdq = luigi.EnumParameter(enum=CachedReferenceDatasetQuery)
 
     def complete(self) -> bool:
         if not super().complete():
+            logger.info(
+                f'UpdatedCachedReferenceDatasetQuery: {self.output().path} does not exist',
+            )
             return False
 
         datasets_to_check = [self.crdq.dataset(self.dataset_type)]


### PR DESCRIPTION
I'm a bit confused about the errors [here](https://console.cloud.google.com/dataproc/jobs/WriteCachedReferenceDatasetQuery_20240319_b5189cc3/monitoring?region=us-central1&project=seqr-project)
for gnomad_qc, namely why the erroring code is executing because the `super().complete()` call should fail

Hopefully these logs will help me