### PR TITLE
try moving clinvar submitter tmp file to gcs before importing

### DIFF
--- a/v03_pipeline/lib/reference_data/clinvar.py
+++ b/v03_pipeline/lib/reference_data/clinvar.py
@@ -177,6 +177,11 @@ def download_and_import_clinvar_submission_summary() -> hl.Table:
         delete=False,
     ) as tmp_file:
         urllib.request.urlretrieve(CLINVAR_SUBMISSION_SUMMARY_URL, tmp_file.name)  # noqa: S310
+        gcs_tmp_file_name = os.path.join(
+            Env.HAIL_TMPDIR,
+            os.path.basename(tmp_file.name),
+        )
+        safely_move_to_gcs(tmp_file.name, gcs_tmp_file_name)
         return hl.import_table(
             tmp_file.name,
             force=True,

--- a/v03_pipeline/lib/reference_data/clinvar.py
+++ b/v03_pipeline/lib/reference_data/clinvar.py
@@ -183,7 +183,7 @@ def download_and_import_clinvar_submission_summary() -> hl.Table:
         )
         safely_move_to_gcs(tmp_file.name, gcs_tmp_file_name)
         return hl.import_table(
-            tmp_file.name,
+            gcs_tmp_file_name,
             force=True,
             filter='^(#[^:]*:|^##).*$',  # removes all comments except for the header line
             types={


### PR DESCRIPTION
getting `hail.utils.java.FatalError: HailException: arguments refer to no files: Vector(/tmp/tmprjuly50t.txt.gz).` in test [run](https://console.cloud.google.com/dataproc/jobs/UpdateVariantAnnotationsTableWithUpdatedReferenceDataset_20240325_f33d2bc6/monitoring?region=us-central1&project=seqr-project)