### PR TITLE
add allele registry step in update vat with samples task

### DIFF
--- a/v03_pipeline/lib/misc/clingen_allele_registry.py
+++ b/v03_pipeline/lib/misc/clingen_allele_registry.py
@@ -30,14 +30,3 @@ def register_alleles(hgvs_expressions: list[str], login: str, password: str) -> 
         message = response['message']
         error = f'\nAPI URL: {URL}\nTYPE: {error_type}\nDESCRIPTION: {description}\nMESSAGE: {message}'
         logger.error(error)
-
-
-register_alleles(
-    [
-        'NC_000001.10:g.865625G>A',
-        'NC_000001.10:g.865627T>C',
-        'NC_000001.10:g.865628G>A',
-    ],
-    'jklugherz_gmail',
-    'XVRJ4NzTC8YrM!t',
-)

--- a/v03_pipeline/lib/misc/clingen_allele_registry.py
+++ b/v03_pipeline/lib/misc/clingen_allele_registry.py
@@ -1,0 +1,43 @@
+import hashlib
+import time
+
+import requests
+
+from v03_pipeline.lib.logger import get_logger
+
+HTTP_REQUEST_TIMEOUT = 5
+
+URL = 'https://reg.genome.network/alleles?file=hgvs'
+
+logger = get_logger(__name__)
+
+
+def register_alleles(hgvs_expressions: list[str], login: str, password: str) -> None:
+    # adapted from https://reg.clinicalgenome.org/doc/scripts/request_with_payload.py
+    identity = hashlib.sha1((login + password).encode('utf-8')).hexdigest()
+    gb_time = str(int(time.time()))
+    token = hashlib.sha1((URL + identity + gb_time).encode('utf-8')).hexdigest()
+    request = URL + '&gbLogin=' + login + '&gbTime=' + gb_time + '&gbToken=' + token
+    res = requests.put(
+        request,
+        data='\n'.join(hgvs_expressions),
+        timeout=HTTP_REQUEST_TIMEOUT,
+    )
+    response = res.json()
+    if not res.ok:
+        error_type = response['errorType']
+        description = response['description']
+        message = response['message']
+        error = f'\nAPI URL: {URL}\nTYPE: {error_type}\nDESCRIPTION: {description}\nMESSAGE: {message}'
+        logger.error(error)
+
+
+register_alleles(
+    [
+        'NC_000001.10:g.865625G>A',
+        'NC_000001.10:g.865627T>C',
+        'NC_000001.10:g.865628G>A',
+    ],
+    'jklugherz_gmail',
+    'XVRJ4NzTC8YrM!t',
+)


### PR DESCRIPTION
options for where in pipeline to register the alleles (I implemented option B here):

A) in a new airflow/luigi task downstream of the annotations table tasks
- doesn't really jive with luigi expecting a file output, and I'm not sure how to get the variants to register (I could pass the variants to register between tasks with the airflow xcom, or use the callset from the input variable to re-create the `new_variants_ht`)

B) within the update annotations table task
- I can easily use the `new_variants_ht` to get what I need to call the register endpoint with
- However, this logic doesn't necessarily belong in the task and really a new step _should_ mean a new pipeline task