### PR TITLE
change clinvar submitters table partitions

### DIFF
--- a/v03_pipeline/lib/reference_data/clinvar.py
+++ b/v03_pipeline/lib/reference_data/clinvar.py
@@ -41,6 +41,7 @@ CLINVAR_GOLD_STARS_LOOKUP = hl.dict(
 CLINVAR_SUBMISSION_SUMMARY_URL = (
     'ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/submission_summary.txt.gz'
 )
+MIN_HT_PARTITIONS = 2000
 logger = get_logger(__name__)
 
 
@@ -127,7 +128,7 @@ def download_and_import_latest_clinvar_vcf(
             drop_samples=True,
             skip_invalid_loci=True,
             contig_recoding=reference_genome.contig_recoding(include_mt=True),
-            min_partitions=2000,
+            min_partitions=MIN_HT_PARTITIONS,
             force_bgz=True,
         )
         mt = mt.annotate_globals(version=_parse_clinvar_release_date(tmp_file.name))
@@ -192,5 +193,5 @@ def download_and_import_clinvar_submission_summary() -> hl.Table:
                 'ReportedPhenotypeInfo': hl.tstr,
             },
             missing='-',
-            min_partitions=3,  # recommended 2-4 partitions per core
+            min_partitions=MIN_HT_PARTITIONS,
         )


### PR DESCRIPTION
make them equal to the clinvar vcf min partitions to hopefully reduce flakiness of the join. this is mostly a guess

yesterday's test [run](https://console.cloud.google.com/dataproc/jobs/UpdateVariantAnnotationsTableWithUpdatedReferenceDataset_20240328_9a449403/monitoring?region=us-central1&project=seqr-project)  succeeded but after multiple attempts