### PR TITLE
use cached clinvar submission table based on etag

### DIFF
--- a/v03_pipeline/lib/misc/io.py
+++ b/v03_pipeline/lib/misc/io.py
@@ -210,10 +210,12 @@ def checkpoint(t: hl.Table | hl.MatrixTable) -> tuple[hl.Table | hl.MatrixTable,
 def write(
     t: hl.Table | hl.MatrixTable,
     destination_path: str,
+    repartition: bool = True,
 ) -> hl.Table | hl.MatrixTable:
     t, path = checkpoint(t)
-    t = t.repartition(
-        compute_hail_n_partitions(file_size_bytes(path)),
-        shuffle=False,
-    )
+    if repartition:
+        t = t.repartition(
+            compute_hail_n_partitions(file_size_bytes(path)),
+            shuffle=False,
+        )
     return t.write(destination_path, overwrite=True)

--- a/v03_pipeline/lib/paths.py
+++ b/v03_pipeline/lib/paths.py
@@ -284,8 +284,8 @@ def new_variants_table_path(
     )
 
 
-def clinvar_dataset_path(etag: str) -> str:
+def clinvar_dataset_path(reference_genome: ReferenceGenome, etag: str) -> str:
     return os.path.join(
         Env.HAIL_TMPDIR,
-        f'clinvar-{etag}.ht',
+        f'clinvar-{reference_genome.value}-{etag}.ht',
     )

--- a/v03_pipeline/lib/paths.py
+++ b/v03_pipeline/lib/paths.py
@@ -284,8 +284,8 @@ def new_variants_table_path(
     )
 
 
-def clinvar_submission_summary_path(etag: str) -> str:
+def clinvar_dataset_path(etag: str) -> str:
     return os.path.join(
         Env.HAIL_TMPDIR,
-        f'clinvar-submissions-{etag}.ht',
+        f'clinvar-{etag}.ht',
     )

--- a/v03_pipeline/lib/paths.py
+++ b/v03_pipeline/lib/paths.py
@@ -282,3 +282,10 @@ def new_variants_table_path(
         run_id,
         'new_variants.ht',
     )
+
+
+def clinvar_submission_summary_path(etag: str) -> str:
+    return os.path.join(
+        Env.HAIL_TMPDIR,
+        f'clinvar-{etag}.ht',
+    )

--- a/v03_pipeline/lib/paths.py
+++ b/v03_pipeline/lib/paths.py
@@ -287,5 +287,5 @@ def new_variants_table_path(
 def clinvar_submission_summary_path(etag: str) -> str:
     return os.path.join(
         Env.HAIL_TMPDIR,
-        f'clinvar-{etag}.ht',
+        f'clinvar-submissions-{etag}.ht',
     )

--- a/v03_pipeline/lib/reference_data/clinvar.py
+++ b/v03_pipeline/lib/reference_data/clinvar.py
@@ -116,14 +116,7 @@ def get_clinvar_ht(
     clinvar_url: str,
     reference_genome: ReferenceGenome,
 ):
-    etag = (
-        requests.head(
-            clinvar_url.format(protocol='https'),
-            timeout=10,
-        )
-        .headers.get('ETag')
-        .strip('"')
-    )
+    etag = requests.head(clinvar_url, timeout=10).headers.get('ETag').strip('"')
     try:
         logger.info(f'Try using cached clinvar ht with etag {etag}')
         ht = hl.read_table(clinvar_dataset_path(reference_genome, etag))
@@ -139,7 +132,7 @@ def download_and_import_latest_clinvar_vcf(
     reference_genome: ReferenceGenome,
 ) -> hl.Table:
     with tempfile.NamedTemporaryFile(suffix='.vcf.gz', delete=False) as tmp_file:
-        urllib.request.urlretrieve(clinvar_url.format(protocol='ftp'), tmp_file.name)  # noqa: S310
+        urllib.request.urlretrieve(clinvar_url, tmp_file.name)  # noqa: S310
         gcs_tmp_file_name = os.path.join(
             Env.HAIL_TMPDIR,
             os.path.basename(tmp_file.name),

--- a/v03_pipeline/lib/reference_data/clinvar.py
+++ b/v03_pipeline/lib/reference_data/clinvar.py
@@ -126,7 +126,7 @@ def get_clinvar_ht(
     else:
         logger.info('Cached clinvar ht not found, downloading latest clinvar vcf')
         ht = download_and_import_latest_clinvar_vcf(clinvar_url, reference_genome)
-        write(ht, clinvar_ht_path)
+        write(ht, clinvar_ht_path, repartition=False)
     return ht
 
 

--- a/v03_pipeline/lib/reference_data/clinvar_test.py
+++ b/v03_pipeline/lib/reference_data/clinvar_test.py
@@ -148,15 +148,11 @@ class ClinvarTest(unittest.TestCase):
         )
 
     @mock.patch(
-        'v03_pipeline.lib.reference_data.clinvar.hl.read_table',
-    )
-    @mock.patch(
-        'v03_pipeline.lib.reference_data.clinvar.download_import_write_submission_summary',
+        'v03_pipeline.lib.reference_data.clinvar.download_and_import_clinvar_submission_summary',
     )
     def test_join_to_submission_summary_ht(
         self,
         mock_download,
-        mock_read_existing_table,
     ):
         vcf_ht = hl.Table.parallelize(
             [
@@ -251,17 +247,6 @@ class ClinvarTest(unittest.TestCase):
             ),
         ]
 
-        # Tests reading cached submission summary table
-        mock_read_existing_table.return_value = submitters_ht
-        ht = join_to_submission_summary_ht(vcf_ht)
-        self.assertEqual(
-            ht.collect(),
-            expected_clinvar_ht_rows,
-        )
-        mock_download.assert_not_called()
-
-        # Tests downloading new submission summary table
-        mock_read_existing_table.side_effect = hl.utils.FatalError('Table not found')
         mock_download.return_value = submitters_ht
         ht = join_to_submission_summary_ht(vcf_ht)
         self.assertEqual(

--- a/v03_pipeline/lib/reference_data/config.py
+++ b/v03_pipeline/lib/reference_data/config.py
@@ -191,7 +191,7 @@ CONFIG = {
     'clinvar': {
         '37': {
             'custom_import': download_and_import_latest_clinvar_vcf,
-            'source_path': 'ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz',
+            'source_path': '{protocol}://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz',
             'select': {'alleleId': 'info.ALLELEID'},
             'custom_select': clinvar_custom_select,
             'enum_select': {
@@ -202,7 +202,7 @@ CONFIG = {
         },
         '38': {
             'custom_import': download_and_import_latest_clinvar_vcf,
-            'source_path': 'ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz',
+            'source_path': '{protocol}://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz',
             'select': {'alleleId': 'info.ALLELEID'},
             'custom_select': clinvar_custom_select,
             'enum_select': {

--- a/v03_pipeline/lib/reference_data/config.py
+++ b/v03_pipeline/lib/reference_data/config.py
@@ -11,7 +11,7 @@ from v03_pipeline.lib.model.definitions import ReferenceGenome
 from v03_pipeline.lib.reference_data.clinvar import (
     CLINVAR_ASSERTIONS,
     CLINVAR_GOLD_STARS_LOOKUP,
-    download_and_import_latest_clinvar_vcf,
+    get_clinvar_ht,
     parsed_and_mapped_clnsigconf,
     parsed_clnsig,
 )
@@ -190,7 +190,7 @@ CONFIG = {
     },
     'clinvar': {
         '37': {
-            'custom_import': download_and_import_latest_clinvar_vcf,
+            'custom_import': get_clinvar_ht,
             'source_path': '{protocol}://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz',
             'select': {'alleleId': 'info.ALLELEID'},
             'custom_select': clinvar_custom_select,
@@ -201,7 +201,7 @@ CONFIG = {
             'filter': lambda ht: ht.locus.contig != 'MT',
         },
         '38': {
-            'custom_import': download_and_import_latest_clinvar_vcf,
+            'custom_import': get_clinvar_ht,
             'source_path': '{protocol}://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz',
             'select': {'alleleId': 'info.ALLELEID'},
             'custom_select': clinvar_custom_select,
@@ -442,8 +442,8 @@ CONFIG = {
     },
     'clinvar_mito': {
         '37': {
-            'custom_import': download_and_import_latest_clinvar_vcf,
-            'source_path': 'ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz',
+            'custom_import': get_clinvar_ht,
+            'source_path': '{protocol}://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz',
             'select': {'alleleId': 'info.ALLELEID'},
             'custom_select': clinvar_custom_select,
             'enum_select': {
@@ -453,8 +453,8 @@ CONFIG = {
             'filter': lambda ht: ht.locus.contig == 'MT',
         },
         '38': {
-            'custom_import': download_and_import_latest_clinvar_vcf,
-            'source_path': 'ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz',
+            'custom_import': get_clinvar_ht,
+            'source_path': '{protocol}://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz',
             'select': {'alleleId': 'info.ALLELEID'},
             'custom_select': clinvar_custom_select,
             'enum_select': {

--- a/v03_pipeline/lib/reference_data/config.py
+++ b/v03_pipeline/lib/reference_data/config.py
@@ -191,7 +191,7 @@ CONFIG = {
     'clinvar': {
         '37': {
             'custom_import': get_clinvar_ht,
-            'source_path': '{protocol}://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz',
+            'source_path': 'https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz',
             'select': {'alleleId': 'info.ALLELEID'},
             'custom_select': clinvar_custom_select,
             'enum_select': {
@@ -202,7 +202,7 @@ CONFIG = {
         },
         '38': {
             'custom_import': get_clinvar_ht,
-            'source_path': '{protocol}://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz',
+            'source_path': 'https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz',
             'select': {'alleleId': 'info.ALLELEID'},
             'custom_select': clinvar_custom_select,
             'enum_select': {
@@ -443,7 +443,7 @@ CONFIG = {
     'clinvar_mito': {
         '37': {
             'custom_import': get_clinvar_ht,
-            'source_path': '{protocol}://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz',
+            'source_path': 'https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz',
             'select': {'alleleId': 'info.ALLELEID'},
             'custom_select': clinvar_custom_select,
             'enum_select': {
@@ -454,7 +454,7 @@ CONFIG = {
         },
         '38': {
             'custom_import': get_clinvar_ht,
-            'source_path': '{protocol}://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz',
+            'source_path': 'https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz',
             'select': {'alleleId': 'info.ALLELEID'},
             'custom_select': clinvar_custom_select,
             'enum_select': {

--- a/v03_pipeline/lib/tasks/reference_data/updated_reference_dataset_collection_test.py
+++ b/v03_pipeline/lib/tasks/reference_data/updated_reference_dataset_collection_test.py
@@ -221,7 +221,7 @@ class UpdatedReferenceDatasetCollectionTaskTest(MockedDatarootTestCase):
                     paths=hl.Struct(
                         primate_ai='gs://seqr-reference-data/GRCh38/primate_ai/PrimateAI_scores_v0.2.liftover_grch38.ht',
                         cadd='gs://seqr-reference-data/GRCh38/CADD/CADD_snvs_and_indels.v1.6.ht',
-                        clinvar='ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz',
+                        clinvar='{protocol}://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz',
                     ),
                     versions=hl.Struct(
                         primate_ai='v0.3',

--- a/v03_pipeline/lib/tasks/reference_data/updated_reference_dataset_collection_test.py
+++ b/v03_pipeline/lib/tasks/reference_data/updated_reference_dataset_collection_test.py
@@ -221,7 +221,7 @@ class UpdatedReferenceDatasetCollectionTaskTest(MockedDatarootTestCase):
                     paths=hl.Struct(
                         primate_ai='gs://seqr-reference-data/GRCh38/primate_ai/PrimateAI_scores_v0.2.liftover_grch38.ht',
                         cadd='gs://seqr-reference-data/GRCh38/CADD/CADD_snvs_and_indels.v1.6.ht',
-                        clinvar='{protocol}://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz',
+                        clinvar='https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz',
                     ),
                     versions=hl.Struct(
                         primate_ai='v0.3',


### PR DESCRIPTION
- HEAD the clinvar submission summary to get the etag
- if gs://seqr-scratch-temp/clinvar-submissions-{etag}.ht exists, use that
- if not, follow existing flow of getting submissions from ftp, adding an additional step to save imported submissions to gs://seqr-scratch-temp/clinvar-submissions-{etag}.ht