### PR TITLE
add stricter AF prefilter option

### DIFF
--- a/v03_pipeline/lib/reference_data/queries.py
+++ b/v03_pipeline/lib/reference_data/queries.py
@@ -19,6 +19,7 @@ TRANSCRIPT_CONSEQUENCE_TERM_RANK_LOOKUP = hl.dict(
     hl.enumerate(TRANSCRIPT_CONSEQUENCE_TERMS, index_first=False),
 )
 GNOMAD_CODING_NONCODING_HIGH_AF_THRESHOLD = 0.90
+ONE_TENTH_PERCENT = 0.001
 ONE_PERCENT = 0.01
 THREE_PERCENT = 0.03
 FIVE_PERCENT = 0.05
@@ -106,8 +107,9 @@ def high_af_variants(
     **_: Any,
 ) -> hl.Table:
     ht = ht.select_globals()
-    ht = ht.filter(ht.gnomad_genomes.AF_POPMAX_OR_GLOBAL > ONE_PERCENT)
+    ht = ht.filter(ht.gnomad_genomes.AF_POPMAX_OR_GLOBAL > ONE_TENTH_PERCENT)
     return ht.select(
+        is_gt_1_percent=ht.gnomad_genomes.AF_POPMAX_OR_GLOBAL > ONE_PERCENT,
         is_gt_3_percent=ht.gnomad_genomes.AF_POPMAX_OR_GLOBAL > THREE_PERCENT,
         is_gt_5_percent=ht.gnomad_genomes.AF_POPMAX_OR_GLOBAL > FIVE_PERCENT,
         is_gt_10_percent=ht.gnomad_genomes.AF_POPMAX_OR_GLOBAL > TEN_PERCENT,


### PR DESCRIPTION
This expands the AF pre-filter table to include another bucket of variants, with an AF between 0.001 and 0.01. This allows us to more strictly prefilter the entries table on searches (like the AIP search) with stricter AF criteria than locus criteria

I am not sure exactly what would have to be run in order to generate this new table, let me know if I need to write anything else to assist with that