### PR TITLE
Raise a validation error if there are SNV_INDEL symbolic alleles (#884)

### DIFF
--- a/v03_pipeline/lib/misc/validation.py
+++ b/v03_pipeline/lib/misc/validation.py
@@ -13,14 +13,19 @@ class SeqrValidationError(Exception):
 
 def validate_allele_type(
     mt: hl.MatrixTable,
+    dataset_type: DatasetType,
 ) -> None:
     ht = mt.rows()
     ht = ht.filter(
-        hl.numeric_allele_type(ht.alleles[0], ht.alleles[1])
-        == hl.genetics.allele_type.AlleleType.UNKNOWN,
+        dataset_type.invalid_allele_types.contains(
+            hl.numeric_allele_type(ht.alleles[0], ht.alleles[1]),
+        ),
     )
     if ht.count() > 0:
-        msg = f'Alleles with Unknown AlleleType are present in the callset: {ht.alleles.collect()}'
+        collected_alleles = sorted(
+            [tuple(x) for x in ht.aggregate(hl.agg.collect_as_set(ht.alleles))],
+        )
+        msg = f'Alleles with invalid AlleleType are present in the callset: {collected_alleles}'
         raise SeqrValidationError(msg)
 
 

--- a/v03_pipeline/lib/misc/validation_test.py
+++ b/v03_pipeline/lib/misc/validation_test.py
@@ -54,6 +54,11 @@ class ValidationTest(unittest.TestCase):
                         position=3,
                         reference_genome='GRCh38',
                     ),
+                    hl.Locus(
+                        contig='chr1',
+                        position=4,
+                        reference_genome='GRCh38',
+                    ),
                 ],
                 'alleles': [
                     ['A', 'T'],
@@ -61,16 +66,18 @@ class ValidationTest(unittest.TestCase):
                     # but are eventually filtered out upstream.
                     ['A', '*'],
                     ['A', '-'],
+                    ['A', '<NON_REF>'],
                 ],
             },
             cols={'s': ['sample_1']},
-            entries={'HL': [[0.0], [0.0], [0.0]]},
+            entries={'HL': [[0.0], [0.0], [0.0], [0.0]]},
         ).key_rows_by('locus', 'alleles')
         self.assertRaisesRegex(
             SeqrValidationError,
-            "Alleles with Unknown AlleleType are present in the callset: \\[\\['A', '-'\\]\\]",
+            "Alleles with invalid AlleleType are present in the callset: \\[\\('A', '-'\\), \\('A', '<NON_REF>'\\)\\]",
             validate_allele_type,
             mt,
+            DatasetType.SNV_INDEL,
         )
 
     def test_validate_imputed_sex_ploidy(self) -> None:

--- a/v03_pipeline/lib/model/dataset_type.py
+++ b/v03_pipeline/lib/model/dataset_type.py
@@ -145,6 +145,20 @@ class DatasetType(str, Enum):
         }[self]
 
     @property
+    def invalid_allele_types(self) -> hl.SetExpression:
+        return {
+            DatasetType.SV: hl.set([hl.genetics.allele_type.AlleleType.UNKNOWN]),
+        }.get(
+            self,
+            hl.set(
+                [
+                    hl.genetics.allele_type.AlleleType.UNKNOWN,
+                    hl.genetics.allele_type.AlleleType.SYMBOLIC,
+                ],
+            ),
+        )
+
+    @property
     def has_lookup_table(self) -> bool:
         return self in {DatasetType.SNV_INDEL, DatasetType.MITO}
 

--- a/v03_pipeline/lib/tasks/validate_callset.py
+++ b/v03_pipeline/lib/tasks/validate_callset.py
@@ -104,7 +104,7 @@ class ValidateCallsetTask(BaseUpdateTask):
             )
 
         if not self.skip_validation and self.dataset_type.can_run_validation:
-            validate_allele_type(mt)
+            validate_allele_type(mt, self.dataset_type)
             validate_no_duplicate_variants(mt)
             validate_expected_contig_frequency(mt, self.reference_genome)
             coding_and_noncoding_ht = hl.read_table(


### PR DESCRIPTION
* Filter NON_REF and raise a validation error if there are other SNV_INDEL symbolic alleles

* ruff

* wrong sign

* Update validate_callset.py

* Update validate_callset.py

* Adjust error message to use a set

* ruff format

* fix

* ruff

* misc