### PR TITLE
fix pedigree parsing for missing parents -- need to preserve missing …

### DIFF
--- a/v03_pipeline/lib/misc/pedigree.py
+++ b/v03_pipeline/lib/misc/pedigree.py
@@ -81,7 +81,7 @@ class Family:
         return hash(self.family_guid)
 
     @staticmethod
-    def parse_direct_lineage(rows: list[hl.Struct]) -> dict[str, Sample]:  # noqa: C901
+    def parse_direct_lineage(rows: list[hl.Struct]) -> dict[str, Sample]:
         samples = {}
         for row in rows:
             samples[row.s] = Sample(

--- a/v03_pipeline/lib/misc/pedigree.py
+++ b/v03_pipeline/lib/misc/pedigree.py
@@ -94,12 +94,7 @@ class Family:
         for row in rows:
             # Maternal GrandParents
             maternal_s = samples[row.s].mother
-            if maternal_s and maternal_s not in samples:
-                # A sample id may be referenced for a proband that has been
-                # removed from the pedigree as an individual.  We handle this by
-                # nulling out the parent here.
-                samples[row.s].mother = None
-            elif maternal_s:
+            if maternal_s and maternal_s in samples:
                 if samples[maternal_s].mother:
                     samples[row.s].maternal_grandmother = samples[maternal_s].mother
                 if samples[maternal_s].father:
@@ -107,9 +102,7 @@ class Family:
 
             # Paternal GrandParents
             paternal_s = samples[row.s].father
-            if paternal_s and paternal_s not in samples:
-                samples[row.s].father = None
-            elif paternal_s:
+            if paternal_s and paternal_s in samples:
                 if samples[paternal_s].mother:
                     samples[row.s].paternal_grandmother = samples[paternal_s].mother
                 if samples[paternal_s].father:

--- a/v03_pipeline/lib/misc/pedigree_test.py
+++ b/v03_pipeline/lib/misc/pedigree_test.py
@@ -479,7 +479,13 @@ class PedigreesTest(unittest.TestCase):
             ),
         )
         self.assertEqual(len(family.samples), 2)
-        self.assertIsNone(family.samples['BBL_BC1-000345_01_D1'].father)
+        self.assertFalse(
+            'BBL_BC1-000345_02_D1' in family.samples,
+        )
+        self.assertEqual(
+            family.samples['BBL_BC1-000345_01_D1'].father,
+            'BBL_BC1-000345_02_D1'
+        ),
         self.assertEqual(
             family.samples['BBL_BC1-000345_01_D1'].mother,
             'BBL_BC1-000345_03_D1',

--- a/v03_pipeline/lib/misc/pedigree_test.py
+++ b/v03_pipeline/lib/misc/pedigree_test.py
@@ -484,8 +484,8 @@ class PedigreesTest(unittest.TestCase):
         )
         self.assertEqual(
             family.samples['BBL_BC1-000345_01_D1'].father,
-            'BBL_BC1-000345_02_D1'
-        ),
+            'BBL_BC1-000345_02_D1',
+        )
         self.assertEqual(
             family.samples['BBL_BC1-000345_01_D1'].mother,
             'BBL_BC1-000345_03_D1',


### PR DESCRIPTION
…parents to ensure siblings are not misidentified