### PR TITLE
add sample qc task as dependency of write_remapped_and_subsetted_callset

### DIFF
--- a/v03_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
+++ b/v03_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
@@ -1,3 +1,4 @@
+
 import hail as hl
 import luigi
 import luigi.util
@@ -28,6 +29,7 @@ from v03_pipeline.lib.tasks.validate_callset import ValidateCallsetTask
 from v03_pipeline.lib.tasks.write_relatedness_check_tsv import (
     WriteRelatednessCheckTsvTask,
 )
+from v03_pipeline.lib.tasks.write_sample_qc_json import WriteSampleQCJsonTask
 from v03_pipeline.lib.tasks.write_sex_check_table import WriteSexCheckTableTask
 from v03_pipeline.lib.tasks.write_validation_errors_for_run import (
     with_persisted_validation_errors,
@@ -81,6 +83,17 @@ class WriteRemappedAndSubsettedCallsetTask(BaseWriteTask):
                 *requirements,
                 self.clone(WriteRelatednessCheckTsvTask),
                 self.clone(WriteSexCheckTableTask),
+            ]
+        if (
+            FeatureFlag.EXPECT_TDR_METRICS
+            and not self.skip_expect_tdr_metrics
+            and self.dataset_type.expect_tdr_metrics(
+                self.reference_genome,
+            )
+        ):
+            requirements = [
+                *requirements,
+                self.clone(WriteSampleQCJsonTask),
             ]
         return requirements
 

--- a/v03_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
+++ b/v03_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
@@ -1,4 +1,3 @@
-
 import hail as hl
 import luigi
 import luigi.util

--- a/v03_pipeline/lib/tasks/write_remapped_and_subsetted_callset_test.py
+++ b/v03_pipeline/lib/tasks/write_remapped_and_subsetted_callset_test.py
@@ -94,6 +94,7 @@ class WriteRemappedAndSubsettedCallsetTaskTest(MockedDatarootTestCase):
             project_pedigree_paths=[TEST_PEDIGREE_3],
             project_i=0,
             skip_validation=True,
+            skip_expect_tdr_metrics=True,
         )
         worker.add(wrsc_task)
         worker.run()
@@ -138,6 +139,7 @@ class WriteRemappedAndSubsettedCallsetTaskTest(MockedDatarootTestCase):
             project_pedigree_paths=[TEST_PEDIGREE_4],
             project_i=0,
             skip_validation=True,
+            skip_expect_tdr_metrics=True,
         )
         worker.add(wrsc_task)
         worker.run()
@@ -203,6 +205,7 @@ class WriteRemappedAndSubsettedCallsetTaskTest(MockedDatarootTestCase):
             project_pedigree_paths=[TEST_PEDIGREE_7],
             project_i=0,
             skip_validation=True,
+            skip_expect_tdr_metrics=True,
         )
         worker.add(wrsc_task)
         worker.run()


### PR DESCRIPTION
another tiny PR. this code path gets explicitly tested without 'skip_expect_tdr_metrics'  in the next PR, which adds sample qc to the metadata.json