### PR TITLE
refactor: add globals to new variants

### DIFF
--- a/v03_pipeline/lib/annotations/misc.py
+++ b/v03_pipeline/lib/annotations/misc.py
@@ -17,7 +17,7 @@ from v03_pipeline.lib.model import DatasetType
 from v03_pipeline.lib.model.definitions import ReferenceGenome
 
 
-def annotate_enums(
+def annotate_formatting_annotation_enum_globals(
     ht: hl.Table,
     reference_genome: ReferenceGenome,
     dataset_type: DatasetType,

--- a/v03_pipeline/lib/annotations/misc.py
+++ b/v03_pipeline/lib/annotations/misc.py
@@ -15,6 +15,36 @@ from v03_pipeline.lib.annotations.enums import (
 )
 from v03_pipeline.lib.model import DatasetType
 from v03_pipeline.lib.model.definitions import ReferenceGenome
+from v03_pipeline.lib.paths import valid_reference_dataset_path
+from v03_pipeline.lib.reference_datasets.reference_dataset import BaseReferenceDataset
+
+
+def annotate_reference_dataset_globals(
+    ht: hl.Table,
+    reference_genome: ReferenceGenome,
+    dataset_type: DatasetType,
+) -> hl.Table:
+    for (
+        reference_dataset
+    ) in BaseReferenceDataset.for_reference_genome_dataset_type_annotations_updates(
+        reference_genome,
+        dataset_type,
+    ):
+        rd_ht = hl.read_table(
+            valid_reference_dataset_path(reference_genome, reference_dataset),
+        )
+        rd_ht_globals = rd_ht.index_globals()
+        ht = ht.annotate_globals(
+            versions=hl.Struct(
+                **ht.globals.versions,
+                **{reference_dataset.name: rd_ht_globals.version},
+            ),
+            enums=hl.Struct(
+                **ht.globals.enums,
+                **{reference_dataset.name: rd_ht_globals.enums},
+            ),
+        )
+    return ht
 
 
 def annotate_formatting_annotation_enum_globals(

--- a/v03_pipeline/lib/reference_datasets/misc.py
+++ b/v03_pipeline/lib/reference_datasets/misc.py
@@ -13,8 +13,6 @@ from v03_pipeline.lib.misc.io import split_multi_hts
 from v03_pipeline.lib.model.dataset_type import DatasetType
 from v03_pipeline.lib.model.definitions import ReferenceGenome
 from v03_pipeline.lib.model.environment import Env
-from v03_pipeline.lib.paths import valid_reference_dataset_path
-from v03_pipeline.lib.reference_datasets import BaseReferenceDataset
 
 BIALLELIC = 2
 
@@ -189,31 +187,3 @@ def copy_to_cloud_storage(file_name: str) -> str:
         cloud_storage_path = os.path.join(Env.HAIL_TMP_DIR, os.path.basename(file_name))
     hfs.copy(file_name, cloud_storage_path)
     return cloud_storage_path
-
-
-def annotate_reference_dataset_globals(
-    ht: hl.Table,
-    reference_genome: ReferenceGenome,
-    dataset_type: DatasetType,
-) -> hl.Table:
-    for (
-        reference_dataset
-    ) in BaseReferenceDataset.for_reference_genome_dataset_type_annotations_updates(
-        reference_genome,
-        dataset_type,
-    ):
-        rd_ht = hl.read_table(
-            valid_reference_dataset_path(reference_genome, reference_dataset),
-        )
-        rd_ht_globals = rd_ht.index_globals()
-        ht = ht.annotate_globals(
-            versions=hl.Struct(
-                **ht.globals.versions,
-                **{reference_dataset.name: rd_ht_globals.version},
-            ),
-            enums=hl.Struct(
-                **ht.globals.enums,
-                **{reference_dataset.name: rd_ht_globals.enums},
-            ),
-        )
-    return ht

--- a/v03_pipeline/lib/reference_datasets/misc.py
+++ b/v03_pipeline/lib/reference_datasets/misc.py
@@ -13,6 +13,8 @@ from v03_pipeline.lib.misc.io import split_multi_hts
 from v03_pipeline.lib.model.dataset_type import DatasetType
 from v03_pipeline.lib.model.definitions import ReferenceGenome
 from v03_pipeline.lib.model.environment import Env
+from v03_pipeline.lib.paths import valid_reference_dataset_path
+from v03_pipeline.lib.reference_datasets import BaseReferenceDataset
 
 BIALLELIC = 2
 
@@ -187,3 +189,31 @@ def copy_to_cloud_storage(file_name: str) -> str:
         cloud_storage_path = os.path.join(Env.HAIL_TMP_DIR, os.path.basename(file_name))
     hfs.copy(file_name, cloud_storage_path)
     return cloud_storage_path
+
+
+def annotate_reference_dataset_globals(
+    ht: hl.Table,
+    reference_genome: ReferenceGenome,
+    dataset_type: DatasetType,
+) -> hl.Table:
+    for (
+        reference_dataset
+    ) in BaseReferenceDataset.for_reference_genome_dataset_type_annotations_updates(
+        reference_genome,
+        dataset_type,
+    ):
+        rd_ht = hl.read_table(
+            valid_reference_dataset_path(reference_genome, reference_dataset),
+        )
+        rd_ht_globals = rd_ht.index_globals()
+        ht = ht.annotate_globals(
+            versions=hl.Struct(
+                **ht.globals.versions,
+                **{reference_dataset.name: rd_ht_globals.version},
+            ),
+            enums=hl.Struct(
+                **ht.globals.enums,
+                **{reference_dataset.name: rd_ht_globals.enums},
+            ),
+        )
+    return ht

--- a/v03_pipeline/lib/tasks/base/base_update_variant_annotations_table.py
+++ b/v03_pipeline/lib/tasks/base/base_update_variant_annotations_table.py
@@ -1,7 +1,6 @@
 import hail as hl
 import luigi
 
-from v03_pipeline.lib.annotations.misc import annotate_enums
 from v03_pipeline.lib.paths import (
     valid_reference_dataset_path,
     variant_annotations_table_path,
@@ -103,4 +102,4 @@ class BaseUpdateVariantAnnotationsTableTask(BaseUpdateTask):
                 migrations=ht.globals.migrations,
                 max_key_=ht.globals.max_key_,
             )
-        return annotate_enums(ht, self.reference_genome, self.dataset_type)
+        return ht

--- a/v03_pipeline/lib/tasks/base/base_update_variant_annotations_table.py
+++ b/v03_pipeline/lib/tasks/base/base_update_variant_annotations_table.py
@@ -2,12 +2,10 @@ import hail as hl
 import luigi
 
 from v03_pipeline.lib.paths import (
-    valid_reference_dataset_path,
     variant_annotations_table_path,
 )
 from v03_pipeline.lib.reference_datasets.reference_dataset import (
     BaseReferenceDataset,
-    ReferenceDataset,
     ReferenceDatasetQuery,
 )
 from v03_pipeline.lib.tasks.base.base_update import BaseUpdateTask
@@ -73,33 +71,4 @@ class BaseUpdateVariantAnnotationsTableTask(BaseUpdateTask):
         )
 
     def update_table(self, ht: hl.Table) -> hl.Table:
-        return ht
-
-    def annotate_globals(
-        self,
-        ht: hl.Table,
-        reference_datasets: set[ReferenceDataset],
-    ) -> hl.Table:
-        ht = ht.annotate_globals(
-            versions=hl.Struct(),
-            enums=hl.Struct(),
-        )
-        for reference_dataset in reference_datasets:
-            rd_ht = hl.read_table(
-                valid_reference_dataset_path(self.reference_genome, reference_dataset),
-            )
-            rd_ht_globals = rd_ht.index_globals()
-            ht = ht.select_globals(
-                versions=hl.Struct(
-                    **ht.globals.versions,
-                    **{reference_dataset.name: rd_ht_globals.version},
-                ),
-                enums=hl.Struct(
-                    **ht.globals.enums,
-                    **{reference_dataset.name: rd_ht_globals.enums},
-                ),
-                updates=ht.globals.updates,
-                migrations=ht.globals.migrations,
-                max_key_=ht.globals.max_key_,
-            )
         return ht

--- a/v03_pipeline/lib/tasks/reference_data/update_variant_annotations_table_with_updated_reference_dataset.py
+++ b/v03_pipeline/lib/tasks/reference_data/update_variant_annotations_table_with_updated_reference_dataset.py
@@ -7,6 +7,9 @@ from v03_pipeline.lib.annotations.misc import (
 )
 from v03_pipeline.lib.logger import get_logger
 from v03_pipeline.lib.paths import valid_reference_dataset_path
+from v03_pipeline.lib.reference_datasets.misc import (
+    annotate_reference_dataset_globals,
+)
 from v03_pipeline.lib.reference_datasets.reference_dataset import (
     BaseReferenceDataset,
     ReferenceDataset,
@@ -103,15 +106,20 @@ class UpdateVariantAnnotationsTableWithUpdatedReferenceDataset(
                 )
                 ht = ht.join(reference_dataset_ht, 'left')
 
+        ht = ht.select_globals(
+            versions=hl.Struct(),
+            enums=hl.Struct(),
+            updates=ht.updates,
+            migrations=ht.migrations,
+            max_key_=ht.max_key_,
+        )
         ht = annotate_formatting_annotation_enum_globals(
             ht,
             self.reference_dataset_ht,
             self.dataset_type,
         )
-        return self.annotate_globals(
+        return annotate_reference_dataset_globals(
             ht,
-            BaseReferenceDataset.for_reference_genome_dataset_type_annotations_updates(
-                self.reference_genome,
-                self.dataset_type,
-            ),
+            self.reference_genome,
+            self.dataset_type,
         )

--- a/v03_pipeline/lib/tasks/reference_data/update_variant_annotations_table_with_updated_reference_dataset.py
+++ b/v03_pipeline/lib/tasks/reference_data/update_variant_annotations_table_with_updated_reference_dataset.py
@@ -2,6 +2,9 @@ import hail as hl
 import luigi
 
 from v03_pipeline.lib.annotations.fields import get_fields
+from v03_pipeline.lib.annotations.misc import (
+    annotate_formatting_annotation_enum_globals,
+)
 from v03_pipeline.lib.logger import get_logger
 from v03_pipeline.lib.paths import valid_reference_dataset_path
 from v03_pipeline.lib.reference_datasets.reference_dataset import (
@@ -100,6 +103,11 @@ class UpdateVariantAnnotationsTableWithUpdatedReferenceDataset(
                 )
                 ht = ht.join(reference_dataset_ht, 'left')
 
+        ht = annotate_formatting_annotation_enum_globals(
+            ht,
+            self.reference_dataset_ht,
+            self.dataset_type,
+        )
         return self.annotate_globals(
             ht,
             BaseReferenceDataset.for_reference_genome_dataset_type_annotations_updates(

--- a/v03_pipeline/lib/tasks/reference_data/update_variant_annotations_table_with_updated_reference_dataset.py
+++ b/v03_pipeline/lib/tasks/reference_data/update_variant_annotations_table_with_updated_reference_dataset.py
@@ -4,12 +4,10 @@ import luigi
 from v03_pipeline.lib.annotations.fields import get_fields
 from v03_pipeline.lib.annotations.misc import (
     annotate_formatting_annotation_enum_globals,
+    annotate_reference_dataset_globals,
 )
 from v03_pipeline.lib.logger import get_logger
 from v03_pipeline.lib.paths import valid_reference_dataset_path
-from v03_pipeline.lib.reference_datasets.misc import (
-    annotate_reference_dataset_globals,
-)
 from v03_pipeline.lib.reference_datasets.reference_dataset import (
     BaseReferenceDataset,
     ReferenceDataset,

--- a/v03_pipeline/lib/tasks/update_variant_annotations_table_with_new_samples.py
+++ b/v03_pipeline/lib/tasks/update_variant_annotations_table_with_new_samples.py
@@ -3,6 +3,9 @@ import luigi
 import luigi.util
 
 from v03_pipeline.lib.annotations.fields import get_fields
+from v03_pipeline.lib.annotations.misc import (
+    annotate_formatting_annotation_enum_globals,
+)
 from v03_pipeline.lib.misc.callsets import get_callset_ht, get_callset_mt
 from v03_pipeline.lib.misc.io import remap_pedigree_hash
 from v03_pipeline.lib.paths import (
@@ -123,6 +126,11 @@ class UpdateVariantAnnotationsTableWithNewSamplesTask(
                 self.reference_genome,
                 self.dataset_type,
             ),
+        )
+        ht = annotate_formatting_annotation_enum_globals(
+            ht,
+            self.reference_dataset_ht,
+            self.dataset_type,
         )
         return ht.annotate_globals(
             updates=ht.updates.union(

--- a/v03_pipeline/lib/tasks/write_new_variants_table.py
+++ b/v03_pipeline/lib/tasks/write_new_variants_table.py
@@ -205,12 +205,12 @@ class WriteNewVariantsTableTask(BaseWriteTask):
         )
         new_variants_ht = annotate_formatting_annotation_enum_globals(
             new_variants_ht,
-            self.reference_dataset_ht,
+            self.reference_genome,
             self.dataset_type,
         )
         new_variants_ht = annotate_reference_dataset_globals(
             new_variants_ht,
-            self.reference_dataset_ht,
+            self.reference_genome,
             self.dataset_type,
         )
         return new_variants_ht.annotate_globals(

--- a/v03_pipeline/lib/tasks/write_new_variants_table.py
+++ b/v03_pipeline/lib/tasks/write_new_variants_table.py
@@ -7,6 +7,7 @@ import luigi.util
 from v03_pipeline.lib.annotations.fields import get_fields
 from v03_pipeline.lib.annotations.misc import (
     annotate_formatting_annotation_enum_globals,
+    annotate_reference_dataset_globals,
 )
 from v03_pipeline.lib.misc.callsets import get_callset_ht
 from v03_pipeline.lib.misc.io import remap_pedigree_hash
@@ -19,9 +20,6 @@ from v03_pipeline.lib.paths import (
 from v03_pipeline.lib.reference_datasets.gencode.mapping_gene_ids import (
     load_gencode_ensembl_to_refseq_id,
     load_gencode_gene_symbol_to_gene_id,
-)
-from v03_pipeline.lib.reference_datasets.misc import (
-    annotate_reference_dataset_globals,
 )
 from v03_pipeline.lib.reference_datasets.reference_dataset import BaseReferenceDataset
 from v03_pipeline.lib.tasks.base.base_loading_run_params import (


### PR DESCRIPTION
Refactors the reference data/ enums globals creation and it from the annotations update to the new variants creation (then uses the globals from that table!)