### PR TITLE
bugfix: ensure family samples are written during migration

### DIFF
--- a/v03_pipeline/lib/tasks/clickhouse_migration/migrate_all_project_entries_to_clickhouse_test.py
+++ b/v03_pipeline/lib/tasks/clickhouse_migration/migrate_all_project_entries_to_clickhouse_test.py
@@ -112,6 +112,10 @@ class MigrateAllProjectEntriesToClickHouseTaskTest(MockedReferenceDatasetsTestCa
                     metadata_json['migration_type'],
                     ClickHouseMigrationType.PROJECT_ENTRIES.value,
                 )
+                self.assertCEqual(
+                    metadata_json['family_samples']['F079280_bh10261'],
+                    ['BH10261-1', 'BH10261-2', 'BH10261-3-T'],
+                )
 
             with hfs.open(
                 pipeline_run_success_file_path(

--- a/v03_pipeline/lib/tasks/clickhouse_migration/migrate_all_project_entries_to_clickhouse_test.py
+++ b/v03_pipeline/lib/tasks/clickhouse_migration/migrate_all_project_entries_to_clickhouse_test.py
@@ -112,7 +112,7 @@ class MigrateAllProjectEntriesToClickHouseTaskTest(MockedReferenceDatasetsTestCa
                     metadata_json['migration_type'],
                     ClickHouseMigrationType.PROJECT_ENTRIES.value,
                 )
-                self.assertCEqual(
+                self.assertEqual(
                     metadata_json['family_samples']['F079280_bh10261'],
                     ['BH10261-1', 'BH10261-2', 'BH10261-3-T'],
                 )

--- a/v03_pipeline/lib/tasks/clickhouse_migration/migrate_project_entries_to_clickhouse.py
+++ b/v03_pipeline/lib/tasks/clickhouse_migration/migrate_project_entries_to_clickhouse.py
@@ -128,7 +128,7 @@ class WriteProjectEntriesMetadataJsonTask(luigi.Task):
                 self.dataset_type,
                 self.sample_type,
                 self.project_guid,
-            )
+            ),
         )
 
     def output(self) -> luigi.Target:


### PR DESCRIPTION
small oversight, but potentially leading to duplicate loads during the migration! 