### PR TITLE
chore: tweak cache bust logic to use size, accounting for frequently changing modification times

### DIFF
--- a/v03_pipeline/lib/paths.py
+++ b/v03_pipeline/lib/paths.py
@@ -73,9 +73,7 @@ def _callset_path_hash(callset_path: str) -> str:
         else:
             # f.modification_time is None for directories
             key = callset_path + str(
-                sum(
-                    (f.size if f.size else 0) for f in shards
-                ),
+                sum((f.size if f.size else 0) for f in shards),
             )
     except FileNotFoundError:
         key = callset_path

--- a/v03_pipeline/lib/paths.py
+++ b/v03_pipeline/lib/paths.py
@@ -73,8 +73,8 @@ def _callset_path_hash(callset_path: str) -> str:
         else:
             # f.modification_time is None for directories
             key = callset_path + str(
-                max(
-                    (f.modification_time if f.modification_time else 0) for f in shards
+                sum(
+                    (f.size if f.size else 0) for f in shards
                 ),
             )
     except FileNotFoundError:

--- a/v03_pipeline/lib/paths_test.py
+++ b/v03_pipeline/lib/paths_test.py
@@ -169,9 +169,9 @@ class TestPaths(unittest.TestCase):
                 hfs.stat_result.FileListEntry(
                     path='v03_pipeline/var/test/callsets/1kg_30variants.vcf',
                     owner=None,
-                    size=104481,
+                    size=1732033623.804012,
                     typ=hfs.stat_result.FileType(2),
-                    modification_time=1732033623.804012,
+                    modification_time=1732033000,
                 ),
             ]
             self.assertEqual(

--- a/v03_pipeline/lib/tasks/write_sample_qc_json_test.py
+++ b/v03_pipeline/lib/tasks/write_sample_qc_json_test.py
@@ -50,6 +50,10 @@ class WriteSampleQCJsonTaskTest(MockedDatarootTestCase):
         mock_tdr_task.return_value = MockCompleteTask()
         mock_tdr_table = Mock()
         mock_tdr_table.path = TEST_TDR_METRICS_FILE
+        # Note, hfs.ls is getting mocked in every module not just write_sample_qc_json?
+        # It seems as though hfs is import-cached somehow, which leads to a single
+        # object being used globally.
+        mock_tdr_table.size = 10
         mock_ls_tdr_dir.return_value = [mock_tdr_table]
         mock_get_pop_pca_scores.return_value = hl.Table.parallelize(
             [


### PR DESCRIPTION
Resolves: https://github.com/broadinstitute/seqr-loading-pipelines/issues/1119