### PR TITLE
Delete failed dataproc jobs when re-running with same run_id

### DIFF
--- a/loading_pipeline/lib/tasks/dataproc/base_run_job_on_dataproc.py
+++ b/loading_pipeline/lib/tasks/dataproc/base_run_job_on_dataproc.py
@@ -84,7 +84,9 @@ class BaseRunJobOnDataprocTask(luigi.Task):
         # Delete the job if it exists and was failed.  This handles manual re-runs of the
         # same run_id.
         if job and job.status.state in FAILURE_STATUSES:
-            logger.error(f'Previous job {self.job_id} failed with state {job.status.state.name}')
+            logger.error(
+                f'Previous job {self.job_id} failed with state {job.status.state.name}'
+            )
             logger.error(job.status.details)
             self.client.delete_job(
                 request={

--- a/loading_pipeline/lib/tasks/dataproc/base_run_job_on_dataproc.py
+++ b/loading_pipeline/lib/tasks/dataproc/base_run_job_on_dataproc.py
@@ -81,6 +81,20 @@ class BaseRunJobOnDataprocTask(luigi.Task):
 
     def run(self):
         job = self.safely_get_job()
+        # Delete the job if it exists and was failed.  This handles manual re-runs of the
+        # same run_id.
+        if job and job.status.state in FAILURE_STATUSES:
+            logger.error(f'Previous job {self.job_id} failed with state {job.status.state.name}')
+            logger.error(job.status.details)
+            self.client.delete_job(
+                request={
+                    'project_id': Env.GCLOUD_PROJECT,
+                    'region': Env.GCLOUD_REGION,
+                    'job_id': self.job_id,
+                },
+            )
+            job = None
+
         if not job:
             self.client.submit_job_as_operation(
                 request={

--- a/loading_pipeline/lib/tasks/dataproc/base_run_job_on_dataproc.py
+++ b/loading_pipeline/lib/tasks/dataproc/base_run_job_on_dataproc.py
@@ -85,7 +85,7 @@ class BaseRunJobOnDataprocTask(luigi.Task):
         # same run_id.
         if job and job.status.state in FAILURE_STATUSES:
             logger.error(
-                f'Previous job {self.job_id} failed with state {job.status.state.name}'
+                f'Previous job {self.job_id} failed with state {job.status.state.name}',
             )
             logger.error(job.status.details)
             self.client.delete_job(


### PR DESCRIPTION
When manually re-running a pipeline without changing run_id, existing job records can block retries since job submission is skipped if a job with that ID already exists. Now delete failed jobs and retry them instead of leaving them stuck. In-progress jobs are left untouched.