### PR TITLE
Local install bugfix

### DIFF
--- a/loading_pipeline/lib/misc/clickhouse.py
+++ b/loading_pipeline/lib/misc/clickhouse.py
@@ -1113,13 +1113,22 @@ def rebuild_gt_stats(
         msg = f'Skipping gt stats rebuild for {reference_genome.value}/{dataset_type.value} {project_guids[:10]}...'
         logger.info(msg)
         return
-    msg = f'Attempting rebuild gt stats for {reference_genome.value}/{dataset_type.value} {project_guids[:10]}...'
-    logger.info(msg)
     table_name_builder = TableNameBuilder(
         reference_genome,
         dataset_type,
         run_id,
     )
+    max_key = logged_query(
+        f"""
+        SELECT max(key) FROM {table_name_builder.dst_table(ClickHouseTable.GT_STATS)}
+        """,
+    )[0][0]
+    if not max_key:
+        msg = f'Skipping gt stats rebuild for empty dataset {reference_genome.value}/{dataset_type.value} {project_guids[:10]}...'
+        logger.info(msg)
+        return
+    msg = f'Attempting rebuild gt stats for {reference_genome.value}/{dataset_type.value} {project_guids[:10]}...'
+    logger.info(msg)
     drop_staging_db()
     create_staging_tables(
         table_name_builder,
@@ -1160,11 +1169,6 @@ def rebuild_gt_stats(
         table_name_builder.staging_dst_prefix,
     )
     # NB: encountered OOMs with large projects, necessitating sharding the insertion query.
-    max_key = logged_query(
-        f"""
-        SELECT max(key) FROM {table_name_builder.dst_table(ClickHouseTable.GT_STATS)}
-        """,
-    )[0][0]
     step = math.ceil(max_key / 5)
     for range_start in range(0, max_key, step):
         range_end = min(range_start + step, max_key + 1)

--- a/loading_pipeline/lib/misc/clickhouse_test.py
+++ b/loading_pipeline/lib/misc/clickhouse_test.py
@@ -1278,6 +1278,21 @@ class ClickhouseTest(MockedDatarootTestCase):
         )
         self.assertCountEqual(gt_stats, [(1, 0)])
 
+        rebuild_gt_stats(
+            ReferenceGenome.GRCh38,
+            DatasetType.MITO,
+            TEST_RUN_ID,
+            ['project_a', 'project_b'],
+        )
+        gt_stats = client.execute(
+            f"""
+            SELECT sum(ac_wes), sum(ac_wgs)
+            FROM
+            {Env.CLICKHOUSE_DATABASE}.`GRCh38/MITO/gt_stats`
+            """,
+        )
+        self.assertCountEqual(gt_stats, [(0, 0)])
+
     @patch.object(
         ClickhouseReferenceDataset,
         'for_reference_genome_dataset_type',

--- a/loading_pipeline/lib/misc/clickhouse_test.py
+++ b/loading_pipeline/lib/misc/clickhouse_test.py
@@ -1278,21 +1278,6 @@ class ClickhouseTest(MockedDatarootTestCase):
         )
         self.assertCountEqual(gt_stats, [(1, 0)])
 
-        rebuild_gt_stats(
-            ReferenceGenome.GRCh38,
-            DatasetType.MITO,
-            TEST_RUN_ID,
-            ['project_a', 'project_b'],
-        )
-        gt_stats = client.execute(
-            f"""
-            SELECT sum(ac_wes), sum(ac_wgs)
-            FROM
-            {Env.CLICKHOUSE_DATABASE}.`GRCh38/MITO/gt_stats`
-            """,
-        )
-        self.assertCountEqual(gt_stats, [(0, 0)])
-
     @patch.object(
         ClickhouseReferenceDataset,
         'for_reference_genome_dataset_type',

--- a/loading_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
+++ b/loading_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
@@ -57,7 +57,7 @@ class WriteRemappedAndSubsettedCallsetTask(BaseWriteTask):
             return False
         mt_globals = hl.read_matrix_table(self.output().path).globals.collect()
         return bool(
-            mt_globals.family_samples
+            mt_globals.family_samples,
         ) and mt_globals.remap_pedigree_hash == remap_pedigree_hash(
             project_pedigree_path(
                 self.reference_genome,

--- a/loading_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
+++ b/loading_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
@@ -56,17 +56,15 @@ class WriteRemappedAndSubsettedCallsetTask(BaseWriteTask):
         if not super().complete():
             return False
         mt_globals = hl.read_matrix_table(self.output().path).globals.collect()
-        return (
-            bool(mt_globals.family_samples)
-            and mt_globals.remap_pedigree_hash
-            == remap_pedigree_hash(
-                project_pedigree_path(
-                    self.reference_genome,
-                    self.dataset_type,
-                    self.sample_type,
-                    self.project_guids[self.project_i],
-                ),
-            )
+        return bool(
+            mt_globals.family_samples
+        ) and mt_globals.remap_pedigree_hash == remap_pedigree_hash(
+            project_pedigree_path(
+                self.reference_genome,
+                self.dataset_type,
+                self.sample_type,
+                self.project_guids[self.project_i],
+            ),
         )
 
     def output(self) -> luigi.Target:

--- a/loading_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
+++ b/loading_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
@@ -55,7 +55,7 @@ class WriteRemappedAndSubsettedCallsetTask(BaseWriteTask):
     def complete(self) -> luigi.Target:
         if not super().complete():
             return False
-        mt_globals = hl.read_matrix_table(self.output().path).globals.collect()
+        mt_globals = hl.read_matrix_table(self.output().path).globals.collect()[0]
         return bool(
             mt_globals.family_samples,
         ) and mt_globals.remap_pedigree_hash == remap_pedigree_hash(

--- a/loading_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
+++ b/loading_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
@@ -55,16 +55,19 @@ class WriteRemappedAndSubsettedCallsetTask(BaseWriteTask):
     def complete(self) -> luigi.Target:
         if not super().complete():
             return False
-        mt_globals = hl.read_matrix_table(self.output().path).globals.collect()[0]
+        mt = hl.read_matrix_table(self.output().path)
         return bool(
-            mt_globals.family_samples,
-        ) and mt_globals.remap_pedigree_hash == remap_pedigree_hash(
-            project_pedigree_path(
-                self.reference_genome,
-                self.dataset_type,
-                self.sample_type,
-                self.project_guids[self.project_i],
-            ),
+            hl.eval(mt.globals.family_samples),
+        ) and hl.eval(
+            mt.globals.remap_pedigree_hash
+            == remap_pedigree_hash(
+                project_pedigree_path(
+                    self.reference_genome,
+                    self.dataset_type,
+                    self.sample_type,
+                    self.project_guids[self.project_i],
+                ),
+            )
         )
 
     def output(self) -> luigi.Target:

--- a/loading_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
+++ b/loading_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
@@ -55,9 +55,9 @@ class WriteRemappedAndSubsettedCallsetTask(BaseWriteTask):
     def complete(self) -> luigi.Target:
         if not super().complete():
             return False
-        mt_globals = hl.eval(hl.read_matrix_table(self.output().path).globals)
+        mt_globals = hl.read_matrix_table(self.output().path).globals.collect()
         return (
-            mt_globals.family_samples
+            bool(mt_globals.family_samples)
             and mt_globals.remap_pedigree_hash
             == remap_pedigree_hash(
                 project_pedigree_path(

--- a/loading_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
+++ b/loading_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
@@ -56,13 +56,16 @@ class WriteRemappedAndSubsettedCallsetTask(BaseWriteTask):
         if not super().complete():
             return False
         globals = hl.eval(hl.read_matrix_table(self.output().path).globals)
-        return globals.family_samples and globals.remap_pedigree_hash == remap_pedigree_hash(
-            project_pedigree_path(
-                self.reference_genome,
-                self.dataset_type,
-                self.sample_type,
-                self.project_guids[self.project_i],
-            ),
+        return (
+            globals.family_samples
+            and globals.remap_pedigree_hash == remap_pedigree_hash(
+                project_pedigree_path(
+                    self.reference_genome,
+                    self.dataset_type,
+                    self.sample_type,
+                    self.project_guids[self.project_i],
+                ),
+            )
         )
 
     def output(self) -> luigi.Target:

--- a/loading_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
+++ b/loading_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
@@ -53,15 +53,15 @@ class WriteRemappedAndSubsettedCallsetTask(BaseWriteTask):
     project_i = luigi.IntParameter()
 
     def complete(self) -> luigi.Target:
-        return super().complete() and hl.eval(
-            hl.read_matrix_table(self.output().path).globals.remap_pedigree_hash
-            == remap_pedigree_hash(
-                project_pedigree_path(
-                    self.reference_genome,
-                    self.dataset_type,
-                    self.sample_type,
-                    self.project_guids[self.project_i],
-                ),
+        if not super().complete():
+            return False
+        globals = hl.eval(hl.read_matrix_table(self.output().path).globals)
+        return globals.family_samples and globals.remap_pedigree_hash == remap_pedigree_hash(
+            project_pedigree_path(
+                self.reference_genome,
+                self.dataset_type,
+                self.sample_type,
+                self.project_guids[self.project_i],
             ),
         )
 

--- a/loading_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
+++ b/loading_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
@@ -58,7 +58,8 @@ class WriteRemappedAndSubsettedCallsetTask(BaseWriteTask):
         globals = hl.eval(hl.read_matrix_table(self.output().path).globals)
         return (
             globals.family_samples
-            and globals.remap_pedigree_hash == remap_pedigree_hash(
+            and globals.remap_pedigree_hash
+            == remap_pedigree_hash(
                 project_pedigree_path(
                     self.reference_genome,
                     self.dataset_type,

--- a/loading_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
+++ b/loading_pipeline/lib/tasks/write_remapped_and_subsetted_callset.py
@@ -55,10 +55,10 @@ class WriteRemappedAndSubsettedCallsetTask(BaseWriteTask):
     def complete(self) -> luigi.Target:
         if not super().complete():
             return False
-        globals = hl.eval(hl.read_matrix_table(self.output().path).globals)
+        mt_globals = hl.eval(hl.read_matrix_table(self.output().path).globals)
         return (
-            globals.family_samples
-            and globals.remap_pedigree_hash
+            mt_globals.family_samples
+            and mt_globals.remap_pedigree_hash
             == remap_pedigree_hash(
                 project_pedigree_path(
                     self.reference_genome,


### PR DESCRIPTION
## Pull request overview

This PR targets a reported failure modes by hardening task completeness checks and making ClickHouse `gt_stats` rebuilds tolerate datasets with no rows.

**Changes:**
- Update `WriteRemappedAndSubsettedCallsetTask.complete()` to validate output globals before considering the task complete.
- Add an early-exit in `rebuild_gt_stats()` when the destination `gt_stats` table is empty.